### PR TITLE
Terraform Kubernetes setup🏗

### DIFF
--- a/terraform/1_k8s_cluster_setup/.gitignore
+++ b/terraform/1_k8s_cluster_setup/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/terraform/1_k8s_cluster_setup/providers.tf
+++ b/terraform/1_k8s_cluster_setup/providers.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = "0.13.5"
+}
+
+provider "kubernetes" { }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,12 @@
+# ACM IaC - Terraform
+
+This section of the repo is dedicated for the use of Terraform to deploy and manage software and configuration.
+
+
+## Folder structure breakdown
+
+| Folder Name | Description |
+| ----------- | ----------- |
+| configurations | Contains tfvars files used to provide environment variables and additional configuration for specific clusters. |
+| 1_k8s_cluster_setup | Installs cluster controllers, daemonsets, etc required for bare-metal cluster operation |
+| 2_k8s_cluster_apps | Installs cluster apps for member usage |


### PR DESCRIPTION
# Terraform Kubernetes setup 🏗

Creates Terraform code to bootstrap some additional cluster configuration after the initial RKE up commands.
This deploys additional CRDs, deployments, and controllers used for bare-metal deployments.