### PR TITLE
🌐 Adding DNS entry for flourishconf.acmuic.org

### DIFF
--- a/azure/terraform/stacks/acm-general/dns.tf
+++ b/azure/terraform/stacks/acm-general/dns.tf
@@ -3,3 +3,16 @@ data "azurerm_dns_zone" "acmuic_app" {
   resource_group_name = azurerm_resource_group.acm_general.name
 }
 
+data "azurerm_dns_zone" "acmuic_org" {
+  name                = "acmuic.org"
+  resource_group_name = azurerm_resource_group.acm_general.name
+}
+
+resource "azurerm_dns_cname_record" "flourishconf_acmuic_org" {
+  name                = "flourishconf"
+  zone_name           = data.azurerm_dns_zone.acmuic_org.name
+  resource_group_name = azurerm_resource_group.acm_general.name
+  ttl                 = 300
+  record              = "docker1.acmuic.org"
+}
+


### PR DESCRIPTION
This PR adds a DNS entry for flourishconf.acmuic.org. This will be a friendly name that will point to a Docker box, hosting the Flourish! 2023 website.

Relates to #18 .