### PR TITLE
Create Ansible Playbook for Longyan configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ The repo is split by major technologies to better organize the various codebases
 │       └── stacks - This folder is a folder of folders, each subfolder contains Terraform stacks to deploy VMs and Proxmox resources
 │   └── ansible - This is where all Ansible code resides for Proxmox hypervisors and VMs
 │       └── playbooks - This folder is a folder of folders, each subfolder contains Ansible playbooks to deploy VMs and Proxmox resources
-└── vsphere - This folder contains all IaC related to VMware ESXi / VSphere hypervisors
-    └── ansible - This is where all Ansible code resides for VSphere VM deployments
-        └── playbooks - This folder is a folder of folders, each subfolder contains Ansible playbooks to deploy VMs and VSphere resources
+├── vsphere - This folder contains all IaC related to VMware ESXi / VSphere hypervisors
+│   └── ansible - This is where all Ansible code resides for VSphere VM deployments
+│       └── playbooks - This folder is a folder of folders, each subfolder contains Ansible playbooks to deploy VMs and VSphere resources
+└── raspberrypi - This folder contains all IaC related to deployed Raspberry Pis
+    └── ansible - This is where all Ansible code resides for deployed Raspberry Pis
+        └── playbooks - This folder is a folder of folders, each subfolder contains Ansible playbooks to configure Raspberry Pis
 ```

--- a/raspberrypi/ansible/playbooks/longyan-rpios/inventory.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/inventory.yml
@@ -1,0 +1,4 @@
+all:
+  hosts:
+    longyan.acmuic.org:
+      ansible_ssh_user: acmadmin

--- a/raspberrypi/ansible/playbooks/longyan-rpios/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/main.yml
@@ -5,6 +5,8 @@
     runner_username: acmrunner
     doorkeeper_controller_git_url: 'https://github.com/lugatuic/doorkeeper-controller.git'
     discord_bot_git_url: 'https://github.com/lugatuic/doorbot-discord.git'
+    install_doorkeeper_controller: true
+    install_doorbot_discord: false
   tasks:
     - name: Create acmrunner group
       become: true
@@ -16,14 +18,12 @@
       ansible.builtin.user:
         name: "{{ runner_username }}"
         groups: "{{ runner_username }}"
-        shell: /bin/bash
+        shell: /usr/bin/tmux
         home: "/opt/{{ runner_username }}"
         comment: Service user used to run the doorkeeper controllers
     - name: Setup autologin
       include_role:
         name: autologin
-      vars:
-        shell: /usr/bin/tmux
     - name: Install tmux
       become: true
       ansible.builtin.package:
@@ -37,9 +37,9 @@
     - name: Setup doorkeeper_controller
       include_role:
         name: doorkeeper_install
-#    - name: Install Discord bot code
-#      ansible.builtin.git:
-#        repo: "{{ discord_bot_git_url }}"
-#        dest: /opt/{{ runner_username }}/doorbot-discord
-#    - name: Enable Discord doorkeeper bot
+      when: install_doorkeeper_controller
+    - name: Install Discord bot code
+      include_role:
+        name: doorbot_install
+      when: install_doorbot_discord
 

--- a/raspberrypi/ansible/playbooks/longyan-rpios/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/main.yml
@@ -1,0 +1,45 @@
+---
+- name: Setup Longyan as the door strike controller
+  hosts: all
+  vars:
+    runner_username: acmrunner
+    doorkeeper_controller_git_url: 'https://github.com/lugatuic/doorkeeper-controller.git'
+    discord_bot_git_url: 'https://github.com/lugatuic/doorbot-discord.git'
+  tasks:
+    - name: Create acmrunner group
+      become: true
+      ansible.builtin.group:
+        name: "{{ runner_username }}"
+        state: present
+    - name: Create acmrunner user
+      become: true
+      ansible.builtin.user:
+        name: "{{ runner_username }}"
+        groups: "{{ runner_username }}"
+        shell: /bin/bash
+        home: "/opt/{{ runner_username }}"
+        comment: Service user used to run the doorkeeper controllers
+    - name: Setup autologin
+      include_role:
+        name: autologin
+      vars:
+        shell: /usr/bin/tmux
+    - name: Install tmux
+      become: true
+      ansible.builtin.package:
+        name: tmux
+        state: present
+    - name: Install git
+      become: true
+      ansible.builtin.package:
+        name: git
+        state: present
+    - name: Setup doorkeeper_controller
+      include_role:
+        name: doorkeeper_install
+#    - name: Install Discord bot code
+#      ansible.builtin.git:
+#        repo: "{{ discord_bot_git_url }}"
+#        dest: /opt/{{ runner_username }}/doorbot-discord
+#    - name: Enable Discord doorkeeper bot
+

--- a/raspberrypi/ansible/playbooks/longyan-rpios/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/main.yml
@@ -17,7 +17,7 @@
       become: true
       ansible.builtin.user:
         name: "{{ runner_username }}"
-        groups: "{{ runner_username }}"
+        groups: "{{ runner_username }},gpio"
         shell: /usr/bin/tmux
         home: "/opt/{{ runner_username }}"
         comment: Service user used to run the doorkeeper controllers

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/.travis.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/README.md
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/README.md
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/README.md
@@ -1,17 +1,17 @@
-Role Name
+Autologin
 =========
 
-A brief description of the role goes here.
+This role sets up terminal autologin for systemd.
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+This role assumes you are using a system using systemd.
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+`user` - This is the name of the username that will be used for autologin.
 
 Dependencies
 ------------
@@ -25,14 +25,14 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: servers
       roles:
-         - { role: username.rolename, x: 42 }
+         - { role: username.autologin, user: runner }
 
 License
 -------
 
-BSD
+MIT
 
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+This role was originally created by Chase Lee as part of the IaC for the Association for Computing Machinery Student Chapter at the University of Illinois at Chicago. For more information, see the repo: https://github.com/acm-uic/IaC

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/defaults/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for autologin
+user: acmrunner
+shell: /bin/bash

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/defaults/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 # defaults file for autologin
 user: acmrunner
-shell: /bin/bash

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/handlers/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/handlers/main.yml
@@ -1,2 +1,7 @@
 ---
 # handlers file for autologin
+- name: Reload systemctl
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: yes
+

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/handlers/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for autologin

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/meta/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/meta/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
-  author: your name
-  description: your role description
-  company: your company (optional)
+  author: ACM@UIC
+  description: A role to setup autologins for systemd-based systems
+  company: ACM@UIC
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -14,7 +14,7 @@ galaxy_info:
   # - GPL-3.0-only
   # - Apache-2.0
   # - CC-BY-4.0
-  license: license (GPL-2.0-or-later, MIT, etc)
+  license: MIT
 
   min_ansible_version: 2.1
 

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/tasks/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+# tasks file for autologin
+- name: Set default init target
+  become: true
+  ansible.builtin.command: systemctl --quiet set-default multi-user.target
+
+- name: Setup console autologin for a specified user
+  become: true
+  ansible.builtin.template:
+    src: autologin.conf.j2
+    dest: /etc/systemd/system/getty@tty1.service.d/autologin.conf
+    owner: root
+    group: root
+    mode: 644
+

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/tasks/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/tasks/main.yml
@@ -1,15 +1,23 @@
 ---
 # tasks file for autologin
+- name: Get current systemd default
+  command: "systemctl get-default"
+  changed_when: false
+  register: systemdefault
+
 - name: Set default init target
   become: true
   ansible.builtin.command: systemctl --quiet set-default multi-user.target
+  when: "'multi-user' not in systemdefault.stdout"
+  notify: "Reload systemctl"
 
-- name: Setup console autologin for a specified user
+- name: "Setup console autologin for {{ username }}"
   become: true
   ansible.builtin.template:
     src: autologin.conf.j2
     dest: /etc/systemd/system/getty@tty1.service.d/autologin.conf
     owner: root
     group: root
-    mode: 644
+    mode: 0644
+  notify: "Reload systemctl"
 

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/templates/autologin.conf.j2
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/templates/autologin.conf.j2
@@ -1,3 +1,6 @@
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty --autologin {{ user }} --noclear %I \{{ shell }}
+ExecStart=-/sbin/agetty --autologin {{ user }} %I $TERM
+
+[Unit]
+StartLimitIntervalSec=1

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/templates/autologin.conf.j2
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/templates/autologin.conf.j2
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin {{ user }} --noclear %I \{{ shell }}

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/tests/inventory
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/tests/test.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - autologin

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/vars/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/autologin/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for autologin

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/.travis.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/README.md
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/README.md
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/README.md
@@ -1,22 +1,22 @@
-Role Name
+Doorbot Discord Install
 =========
 
-A brief description of the role goes here.
+This role installs the doorbot-discord on a system
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+The user that this application is being run under must be created beforehand.
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+`runner_username` - This is the unix user that the application will be running under.
 
 Dependencies
 ------------
 
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+This program expects an installed and working version of the doorkeeper_controller on the system.
 
 Example Playbook
 ----------------
@@ -25,14 +25,14 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: servers
       roles:
-         - { role: username.rolename, x: 42 }
+         - { role: username.doorbot_install, runner_username: acmrunner }
 
 License
 -------
 
-BSD
+MIT
 
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+This role was originally created as part of the IaC for the Association for Computing Machinery Student Chapter at the University of Illinois at Chicago. For more information, see the repo: https://github.com/acm-uic/IaC

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/defaults/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for doorbot_install

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/handlers/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for doorbot_install

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/meta/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/meta/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
-  author: your name
-  description: your role description
-  company: your company (optional)
+  author: ACM@UIC
+  description: A role to setup autologins for systemd-based systems
+  company: ACM@UIC
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -14,7 +14,7 @@ galaxy_info:
   # - GPL-3.0-only
   # - Apache-2.0
   # - CC-BY-4.0
-  license: license (GPL-2.0-or-later, MIT, etc)
+  license: MIT
 
   min_ansible_version: 2.1
 

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/tasks/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# tasks file for doorbot_install
+- name: Download code
+  ansible.builtin.git:
+    repo: "{{ discord_bot_git_url }}"
+    dest: /opt/{{ runner_username }}/doorbot-discord
+    force: true
+

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/tests/inventory
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/tests/test.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - doorbot_install

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/vars/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorbot_install/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for doorbot_install

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/.travis.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/README.md
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/README.md
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/README.md
@@ -1,17 +1,17 @@
-Role Name
+Doorkeeper Install
 =========
 
-A brief description of the role goes here.
+This role installs and configures the doorkeeper to run on a machine for a given runner user.
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+The user that this application runs under must already be created.
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+`runner_username` - This is the Unix username of the user that we will be installing the application under.
 
 Dependencies
 ------------
@@ -25,14 +25,15 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: servers
       roles:
-         - { role: username.rolename, x: 42 }
+         - { role: username.doorkeeper_install, runner_username: acmrunner }
 
 License
 -------
 
-BSD
+MIT
 
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+This role was originally created by Chase Lee as part of the IaC for the Association for Computing Machinery Student Chapter at the University of Illinois at Chicago. For more information, see the repo: https://github.com/acm-uic/IaC
+

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/defaults/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for doorkeeper_install

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/handlers/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for doorkeeper_install

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/meta/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/meta/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
-  author: your name
-  description: your role description
-  company: your company (optional)
+  author: ACM@UIC
+  description: A role to setup autologins for systemd-based systems
+  company: ACM@UIC
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -14,7 +14,7 @@ galaxy_info:
   # - GPL-3.0-only
   # - Apache-2.0
   # - CC-BY-4.0
-  license: license (GPL-2.0-or-later, MIT, etc)
+  license: MIT
 
   min_ansible_version: 2.1
 

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/tasks/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/tasks/main.yml
@@ -5,6 +5,7 @@
   ansible.builtin.git:
     repo: "{{ doorkeeper_controller_git_url }}"
     dest: "/opt/{{ runner_username }}/doorkeeper_controller"
+    force: true
 - name: Set repo ownership
   become: true
   ansible.builtin.file:
@@ -17,9 +18,17 @@
 - name: Setup autostart shell
   become: true
   ansible.builtin.template:
-    src: bashrc.j2
-    dest: "/opt/{{ runner_username }}/.bashrc"
+    src: user_tmux.conf.j2
+    dest: "/opt/{{ runner_username }}/.tmux.conf"
     owner: "{{ runner_username }}"
     group: "{{ runner_username }}"
-    mode: 644
+    mode: 0644
+- name: Setup tmux configuration
+  become: true
+  ansible.builtin.template:
+    src: tmux.conf.j2
+    dest: "/etc/tmux.conf"
+    owner: root
+    group: root
+    mode: 0644
 

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/tasks/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+# tasks file for doorkeeper_install
+- name: Install doorkeeper-controller code and scripts
+  become: true
+  ansible.builtin.git:
+    repo: "{{ doorkeeper_controller_git_url }}"
+    dest: "/opt/{{ runner_username }}/doorkeeper_controller"
+- name: Set repo ownership
+  become: true
+  ansible.builtin.file:
+    path: "/opt/{{ runner_username }}/doorkeeper_controller"
+    state: directory
+    recurse: true
+    owner: "{{ runner_username }}"
+    group: "{{ runner_username }}"
+#- name: Configure doorkeeper-controller scripts
+- name: Setup autostart shell
+  become: true
+  ansible.builtin.template:
+    src: bashrc.j2
+    dest: "/opt/{{ runner_username }}/.bashrc"
+    owner: "{{ runner_username }}"
+    group: "{{ runner_username }}"
+    mode: 644
+

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/templates/bash_login.j2
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/templates/bash_login.j2
@@ -1,0 +1,6 @@
+if [ -x "$(command -v tmux)" ] && [ -z "${TMUX}" ]; then
+  echo "TMUX should be started here"
+  tmux attach || tmux >/dev/null 2>&1
+else
+  echo "Requirements not met, TMUX not starting."
+fi

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/templates/bash_login.j2
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/templates/bash_login.j2
@@ -1,6 +1,0 @@
-if [ -x "$(command -v tmux)" ] && [ -z "${TMUX}" ]; then
-  echo "TMUX should be started here"
-  tmux attach || tmux >/dev/null 2>&1
-else
-  echo "Requirements not met, TMUX not starting."
-fi

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/templates/bashrc.j2
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/templates/bashrc.j2
@@ -1,0 +1,3 @@
+if [ -x "$(command -v tmux)" ] && [ -n "${DISPLAY}" ] && [ -z "${TMUX}" ]; then
+  tmux attach || tmux >/dev/null 2>&1
+fi

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/templates/bashrc.j2
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/templates/bashrc.j2
@@ -1,3 +1,0 @@
-if [ -x "$(command -v tmux)" ] && [ -n "${DISPLAY}" ] && [ -z "${TMUX}" ]; then
-  tmux attach || tmux >/dev/null 2>&1
-fi

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/templates/tmux.conf.j2
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/templates/tmux.conf.j2
@@ -1,0 +1,1 @@
+set-option -g default-shell /bin/bash

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/templates/user_tmux.conf.j2
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/templates/user_tmux.conf.j2
@@ -1,0 +1,1 @@
+set-option -g default-command /opt/{{ runner_username }}/doorkeeper_controller/card_reader.sh

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/tests/inventory
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/tests/test.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - doorkeeper_install

--- a/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/vars/main.yml
+++ b/raspberrypi/ansible/playbooks/longyan-rpios/roles/doorkeeper_install/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for doorkeeper_install


### PR DESCRIPTION
This PR creates a base playbook to setup the Longyan Pi with it's configuration. The Pi was newly reimaged with Raspberry Pi OS.

This playbook does the following things:
- Makes the Pi autologin to the text console
- Sets the autologin user to `acmrunner`
- Creates the `acmrunner` user
- Installs git & tmux
- Configures the `acmrunner` tmux environment
- Installs the doorkeeper_controller codebase

Things that this playbook does not take into account.
- Allowed UINs that have been previously allowed in the configuration
- Setup of the doorbot. A stub role as been created in the meantime.