### PR TITLE
Allowing the addition of statically-set owner ids

### DIFF
--- a/azure/terraform/stacks/acm-general/configuration/prod.tfvars
+++ b/azure/terraform/stacks/acm-general/configuration/prod.tfvars
@@ -1,1 +1,2 @@
 # Prod environment variables
+additional_owner_ids = ["920bf583-cb9b-4365-a61e-bb33988c5484"]

--- a/azure/terraform/stacks/acm-general/service_principal.tf
+++ b/azure/terraform/stacks/acm-general/service_principal.tf
@@ -8,7 +8,7 @@ resource "azuread_application" "terraform_sysadmin_demo" {
 resource "azuread_service_principal" "terraform_sysadmin_demo" {
   application_id               = azuread_application.terraform_sysadmin_demo.application_id
   app_role_assignment_required = false
-  owners                       = [data.azuread_client_config.current.object_id]
+  owners                       = concat([data.azuread_client_config.current.object_id], var.additional_owner_ids)
 }
 
 resource "azuread_service_principal_password" "terraform_sysadmin_demo" {

--- a/azure/terraform/stacks/acm-general/variables.tf
+++ b/azure/terraform/stacks/acm-general/variables.tf
@@ -1,0 +1,4 @@
+variable "additional_owner_ids" {
+  type    = list(string)
+  default = []
+}


### PR DESCRIPTION
This PR allows Terraform to specify additional owner ids for usage on CI/CD-created resources (where applicable).