### PR TITLE
Using application password instead of service principal password

### DIFF
--- a/azure/terraform/stacks/acm-general/service_principal.tf
+++ b/azure/terraform/stacks/acm-general/service_principal.tf
@@ -11,8 +11,9 @@ resource "azuread_service_principal" "terraform_sysadmin_demo" {
   owners                       = concat([data.azuread_client_config.current.object_id], var.additional_owner_ids)
 }
 
-resource "azuread_service_principal_password" "terraform_sysadmin_demo" {
-  display_name         = "rbac-sysadmindemo"
-  service_principal_id = azuread_service_principal.terraform_sysadmin_demo.object_id
-  end_date_relative    = "240h"
+resource "azuread_application_password" "terraform_sysadmin_demo" {
+  application_object_id = azuread_application.terraform_sysadmin_demo.object_id
+  display_name          = "rbac-sysadmindemo-apppass"
+  end_date_relative     = "240h"
 }
+


### PR DESCRIPTION
Associating the application password with the application, rather than the service principal for visibility.