### PR TITLE
Adding additional permissions for the demo service account

### DIFF
--- a/azure/terraform/stacks/acm-general/configuration/prod.tfvars
+++ b/azure/terraform/stacks/acm-general/configuration/prod.tfvars
@@ -1,2 +1,5 @@
 # Prod environment variables
-additional_owner_ids = ["920bf583-cb9b-4365-a61e-bb33988c5484"]
+additional_owner_ids = [
+  "21ec2c63-534d-4cfb-bc43-83773ce40e54", #terraform-svc
+  "920bf583-cb9b-4365-a61e-bb33988c5484"  #clee231
+]

--- a/azure/terraform/stacks/acm-general/service_principal.tf
+++ b/azure/terraform/stacks/acm-general/service_principal.tf
@@ -1,6 +1,9 @@
 data "azuread_client_config" "current" {}
 
+data "azurerm_client_config" "current" {}
+
 data "azurerm_subscription" "primary" {}
+
 
 resource "azuread_application" "terraform_sysadmin_demo" {
   display_name = "terraform-sysadmindemo-svc"

--- a/azure/terraform/stacks/acm-general/service_principal.tf
+++ b/azure/terraform/stacks/acm-general/service_principal.tf
@@ -1,5 +1,3 @@
-data "azuread_client_config" "current" {}
-
 data "azurerm_client_config" "current" {}
 
 data "azurerm_subscription" "primary" {}
@@ -7,13 +5,13 @@ data "azurerm_subscription" "primary" {}
 
 resource "azuread_application" "terraform_sysadmin_demo" {
   display_name = "terraform-sysadmindemo-svc"
-  owners       = concat([data.azuread_client_config.current.object_id], var.additional_owner_ids)
+  owners       = var.additional_owner_ids # Azure AD Owner IDs
 }
 
 resource "azuread_service_principal" "terraform_sysadmin_demo" {
   application_id               = azuread_application.terraform_sysadmin_demo.application_id
   app_role_assignment_required = false
-  owners                       = concat([data.azuread_client_config.current.object_id], var.additional_owner_ids)
+  owners                       = var.additional_owner_ids # Azure AD Owner IDs
 }
 
 resource "azuread_application_password" "terraform_sysadmin_demo" {

--- a/azure/terraform/stacks/acm-general/service_principal.tf
+++ b/azure/terraform/stacks/acm-general/service_principal.tf
@@ -1,5 +1,7 @@
 data "azuread_client_config" "current" {}
 
+data "azurerm_subscription" "primary" {}
+
 resource "azuread_application" "terraform_sysadmin_demo" {
   display_name = "terraform-sysadmindemo-svc"
   owners       = concat([data.azuread_client_config.current.object_id], var.additional_owner_ids)
@@ -15,5 +17,17 @@ resource "azuread_application_password" "terraform_sysadmin_demo" {
   application_object_id = azuread_application.terraform_sysadmin_demo.object_id
   display_name          = "rbac-sysadmindemo-apppass"
   end_date_relative     = "240h"
+}
+
+resource "azurerm_role_assignment" "terraform_sysadmin_demo_reader" {
+  scope                = data.azurerm_subscription.primary.id
+  role_definition_name = "Reader"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_role_assignment" "terraform_sysadmin_demo_dns" {
+  scope                = data.azurerm_subscription.primary.id
+  role_definition_name = "DNS Zone Contributor"
+  principal_id         = data.azurerm_client_config.current.object_id
 }
 

--- a/azure/terraform/stacks/acm-general/variables.tf
+++ b/azure/terraform/stacks/acm-general/variables.tf
@@ -1,5 +1,5 @@
 variable "additional_owner_ids" {
-  type    = list(string)
-  default = []
+  type        = list(string)
+  default     = []
   description = "Azure AD Owner IDs attached to resources"
 }

--- a/azure/terraform/stacks/acm-general/variables.tf
+++ b/azure/terraform/stacks/acm-general/variables.tf
@@ -1,4 +1,5 @@
 variable "additional_owner_ids" {
   type    = list(string)
   default = []
+  description = "Azure AD Owner IDs attached to resources"
 }


### PR DESCRIPTION
Adding `Reader` and `DNS Contributor` permissions to the service account.