### PR TITLE
📔 Feature/ArgoCD Configuration

### DIFF
--- a/kubernetes/argocd/stacks/common/argo_repos.yml
+++ b/kubernetes/argocd/stacks/common/argo_repos.yml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bitnami
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  name: bitnami
+  url: https://charts.bitnami.com/bitnami
+  type: helm
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: traefik
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  name: traefik
+  url: https://helm.traefik.io/traefik
+  type: helm

--- a/kubernetes/argocd/stacks/common/metallb.yml
+++ b/kubernetes/argocd/stacks/common/metallb.yml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metallb
+spec:
+  destination:
+    name: ''
+    namespace: metallb-system
+    server: 'https://kubernetes.default.svc'
+  source:
+    path: ''
+    repoURL: 'https://charts.bitnami.com/bitnami'
+    targetRevision: 4.5.5
+    chart: metallb
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  # A name for the address pool. Services can request allocation
+  # from a specific address pool using this name.
+  name: acmuic
+  namespace: metallb-system
+spec:
+  # A list of IP address ranges over which MetalLB has
+  # authority. You can list multiple ranges in a single pool, they
+  # will all share the same settings. Each range can be either a
+  # CIDR prefix, or an explicit start-end range of IPs.
+  addresses:
+    - 172.29.8.0/21
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2
+  namespace: metallb-system

--- a/kubernetes/terraform/stacks/1_k8s_cluster_setup/README.md
+++ b/kubernetes/terraform/stacks/1_k8s_cluster_setup/README.md
@@ -1,0 +1,17 @@
+# Kubernetes Cluster Bootstrap Setup
+
+## Required Variables
+
+The following environment variables need to be present before deployment:
+
+- `TF_VAR_deploy_key` - This is the deployment SSH key used for accessing Github repos.
+
+- `KUBE_CONFIG_PATH` - This is the absolute filepath pointing to the kubeconfig file used to auth to the cluster. 
+
+## Manual Terraform Deployment
+
+```bash
+terraform init
+terraform plan -var-file configurations/acmapp_prod.tfvars
+terraform apply -var-file configurations/acmapp_prod.tfvars
+```

--- a/kubernetes/terraform/stacks/1_k8s_cluster_setup/argo_config.tf
+++ b/kubernetes/terraform/stacks/1_k8s_cluster_setup/argo_config.tf
@@ -21,9 +21,6 @@ resource "kubernetes_manifest" "application_cluster_config" {
     "apiVersion" = "argoproj.io/v1alpha1"
     "kind"       = "Application"
     "metadata" = {
-      "labels" = {
-        "argocd.argoproj.io/secret-type" = "repository"
-      }
       "name"      = "iac"
       "namespace" = "argocd"
     }

--- a/kubernetes/terraform/stacks/1_k8s_cluster_setup/argo_config.tf
+++ b/kubernetes/terraform/stacks/1_k8s_cluster_setup/argo_config.tf
@@ -1,0 +1,53 @@
+resource "kubernetes_secret" "secret_argocd_github_repo" {
+  metadata {
+    labels = {
+      "argocd.argoproj.io/secret-type" = "repository"
+    }
+    name      = "github-repo"
+    namespace = "argocd"
+  }
+  data = {
+    "name"          = "IaC"
+    "project"       = "default"
+    "type"          = "git"
+    "url"           = "git@github.com:acm-uic/IaC.git"
+    "sshPrivateKey" = var.deploy_key
+  }
+}
+
+resource "kubernetes_manifest" "application_cluster_config" {
+  depends_on = [helm_release.argocd]
+  manifest = {
+    "apiVersion" = "argoproj.io/v1alpha1"
+    "kind"       = "Application"
+    "metadata" = {
+      "labels" = {
+        "argocd.argoproj.io/secret-type" = "repository"
+      }
+      "name"      = "iac"
+      "namespace" = "argocd"
+    }
+    "spec" = {
+      "project" = "default"
+      "destination" = {
+        "namespace" = "argocd"
+        "server"    = "https://kubernetes.default.svc"
+      }
+      "source" = {
+        "repoURL"        = "git@github.com:acm-uic/IaC.git"
+        "targetRevision" = "HEAD"
+        "path"           = "kubernetes/argocd/stacks/common"
+        "directory" = {
+          "recurse" = true
+          "jsonnet" = {}
+        }
+      }
+      "syncPolicy" = {
+        "automated" = {
+          "prune"    = true
+          "selfHeal" = true
+        }
+      }
+    }
+  }
+}

--- a/kubernetes/terraform/stacks/1_k8s_cluster_setup/variables.tf
+++ b/kubernetes/terraform/stacks/1_k8s_cluster_setup/variables.tf
@@ -36,3 +36,8 @@ variable "azure_dns_resource_group" {
   description = "The resourceGroup of the DNS Zone"
 }
 
+variable "deploy_key" {
+  type        = string
+  description = "The SSH private key used for deployment and pulling from Github repos"
+  sensitive   = true
+}


### PR DESCRIPTION
This PR defines repositories used within ArgoCD for future Helm deployments. This also sets up an application within ArgoCD to start configuring the cluster based on configuration located in `kuberetes/argocd/stacks/common`.

No automation is running this Terraform currently, so it is currently being manually run on an adhoc basis. This will change later once we install Github runners onto the cluster.