### PR TITLE
🪙 Feature/Metallb

### DIFF
--- a/kubernetes/argocd/stacks/common/metallb.yml
+++ b/kubernetes/argocd/stacks/common/metallb.yml
@@ -39,3 +39,9 @@ spec:
   # CIDR prefix, or an explicit start-end range of IPs.
   addresses:
     - 172.29.8.0/21
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2
+  namespace: metallb-system

--- a/kubernetes/argocd/stacks/common/metallb.yml
+++ b/kubernetes/argocd/stacks/common/metallb.yml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metallb
+spec:
+  destination:
+    name: ''
+    namespace: metallb-system
+    server: 'https://kubernetes.default.svc'
+  source:
+    path: ''
+    repoURL: 'https://charts.bitnami.com/bitnami'
+    targetRevision: 4.5.5
+    chart: metallb
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  # A name for the address pool. Services can request allocation
+  # from a specific address pool using this name.
+  name: acmuic
+  namespace: metallb-system
+spec:
+  # A list of IP address ranges over which MetalLB has
+  # authority. You can list multiple ranges in a single pool, they
+  # will all share the same settings. Each range can be either a
+  # CIDR prefix, or an explicit start-end range of IPs.
+  addresses:
+    - 172.29.8.0/21


### PR DESCRIPTION
This PR installs MetalLB on the Kubernetes cluster. This also specifies the IP pool range to be used by the load balancer.