### PR TITLE
👮 bug/MetalLB Pod Security

### DIFF
--- a/kubernetes/argocd/stacks/common/metallb.yml
+++ b/kubernetes/argocd/stacks/common/metallb.yml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    # The following labels are required to allow MetalLB to use
+    # additional networking protocols for L2 advertisement.
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged

--- a/kubernetes/argocd/stacks/common/metallb.yml
+++ b/kubernetes/argocd/stacks/common/metallb.yml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: metallb-system
 ---
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
This PR updates the namespace for MetalLB.
Since MetalLB is dealing with the L2 network layer, it requires additional permissions to advertise the IP addresses it will be managing. By adding pod security labels, we allow privileged containers to run within the namespace.

The original error message during deployment is as follows:

From the daemonset-controller:
```
Error creating: pods "metallb-speaker-cqkt6" is forbidden: violates PodSecurity "baseline:latest": non-default capabilities (container "metallb-speaker" must not include "NET_ADMIN", "NET_RAW", "SYS_ADMIN" in securityContext.capabilities.add), host namespaces (hostNetwork=true), hostPort (container "metallb-speaker" uses hostPort 7472)
```