### PR TITLE
🚦 Feature/Traefik

### DIFF
--- a/kubernetes/argocd/stacks/common/argo_repos.yml
+++ b/kubernetes/argocd/stacks/common/argo_repos.yml
@@ -20,5 +20,5 @@ metadata:
     argocd.argoproj.io/secret-type: repository
 stringData:
   name: traefik
-  url: https://helm.traefik.io/traefik
+  url: https://traefik.github.io/charts
   type: helm

--- a/kubernetes/argocd/stacks/common/traefik.yml
+++ b/kubernetes/argocd/stacks/common/traefik.yml
@@ -20,6 +20,12 @@ spec:
     repoURL: 'https://traefik.github.io/charts'
     targetRevision: 23.1.0
     chart: traefik
+    helm:
+      parameters:
+        - name: ingressRoute.dashboard.matchRule
+          value: >-
+            Host(`traefik.acmuic.org`) && PathPrefix(`/dashboard`) ||
+            PathPrefix(`/api`)
   sources: []
   project: default
   syncPolicy:

--- a/kubernetes/argocd/stacks/common/traefik.yml
+++ b/kubernetes/argocd/stacks/common/traefik.yml
@@ -26,20 +26,3 @@ spec:
     automated:
       prune: true
       selfHeal: true
----
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
-metadata:
-  name: dashboard
-  namespace: traefik
-  annotations:
-    argocd.argoproj.io/sync-wave: "2"
-spec:
-  entryPoints:
-    - web
-  routes:
-    - match: Host(`traefik.acmuic.org`) && (PathPrefix(`/dashboard`) || PathPrefix(`/api`))
-      kind: Rule
-      services:
-        - name: api@internal
-          kind: TraefikService

--- a/kubernetes/argocd/stacks/common/traefik.yml
+++ b/kubernetes/argocd/stacks/common/traefik.yml
@@ -26,6 +26,8 @@ spec:
           value: >-
             Host(`traefik.acmuic.org`) && PathPrefix(`/dashboard`) ||
             PathPrefix(`/api`)
+        - name: ingressRoute.dashboard.entryPoints[0]
+          value: web
   sources: []
   project: default
   syncPolicy:

--- a/kubernetes/argocd/stacks/common/traefik.yml
+++ b/kubernetes/argocd/stacks/common/traefik.yml
@@ -1,0 +1,45 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: traefik
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: traefik
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  destination:
+    name: ''
+    namespace: traefik
+    server: 'https://kubernetes.default.svc'
+  source:
+    path: ''
+    repoURL: 'https://traefik.github.io/charts'
+    targetRevision: 23.1.0
+    chart: traefik
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: dashboard
+  namespace: traefik
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`traefik.acmuic.org`) && (PathPrefix(`/dashboard`) || PathPrefix(`/api`))
+      kind: Rule
+      services:
+        - name: api@internal
+          kind: TraefikService


### PR DESCRIPTION
This PR installs Traefik on the Kubernetes cluster.
This provides ingress support for other services.

In general, we can use the `IngressRoute` CRD to specify routing information for a given service. (See here for more info: https://doc.traefik.io/traefik/routing/providers/kubernetes-crd/#kind-ingressroute)