### PR TITLE
💽 Feature/Mayastor

### DIFF
--- a/kubernetes/argocd/stacks/common/argo_repos.yml
+++ b/kubernetes/argocd/stacks/common/argo_repos.yml
@@ -34,3 +34,15 @@ stringData:
   name: mayastor
   url: https://openebs.github.io/mayastor-extensions
   type: helm
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rimusz
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  name: rimusz
+  url: https://charts.rimusz.net
+  type: helm

--- a/kubernetes/argocd/stacks/common/argo_repos.yml
+++ b/kubernetes/argocd/stacks/common/argo_repos.yml
@@ -34,15 +34,3 @@ stringData:
   name: mayastor
   url: https://openebs.github.io/mayastor-extensions
   type: helm
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mayastor
-  namespace: argocd
-  labels:
-    argocd.argoproj.io/secret-type: repository
-stringData:
-  name: mayastor
-  url: https://openebs.github.io/mayastor-extensions
-  type: helm

--- a/kubernetes/argocd/stacks/common/argo_repos.yml
+++ b/kubernetes/argocd/stacks/common/argo_repos.yml
@@ -22,3 +22,15 @@ stringData:
   name: traefik
   url: https://traefik.github.io/charts
   type: helm
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mayastor
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  name: mayastor
+  url: https://openebs.github.io/mayastor-extensions
+  type: helm

--- a/kubernetes/argocd/stacks/common/hostpath-provisioner.yml
+++ b/kubernetes/argocd/stacks/common/hostpath-provisioner.yml
@@ -28,6 +28,8 @@ spec:
       parameters:
         - name: storageClass.defaultClass
           value: 'false'
+        - name: nodeHostPath
+          value: '/var/hostpath-provisioner'
   project: default
   syncPolicy:
     automated:

--- a/kubernetes/argocd/stacks/common/hostpath-provisioner.yml
+++ b/kubernetes/argocd/stacks/common/hostpath-provisioner.yml
@@ -18,7 +18,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "1"
 spec:
   destination:
-    namespace: traefik
+    namespace: hostpath-provisioner
     server: 'https://kubernetes.default.svc'
   source:
     repoURL: 'https://charts.rimusz.net'

--- a/kubernetes/argocd/stacks/common/hostpath-provisioner.yml
+++ b/kubernetes/argocd/stacks/common/hostpath-provisioner.yml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    # The following labels are required to allow hostpath-provisioner
+    # to use additional networking and host-level volume operations.
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+  name: hostpath-provisioner
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hostpath-provisioner
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  destination:
+    namespace: traefik
+    server: 'https://kubernetes.default.svc'
+  source:
+    repoURL: 'https://charts.rimusz.net'
+    targetRevision: 0.2.13
+    chart: hostpath-provisioner
+    helm:
+      parameters:
+        - name: storageClass.defaultClass
+          value: false
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/kubernetes/argocd/stacks/common/hostpath-provisioner.yml
+++ b/kubernetes/argocd/stacks/common/hostpath-provisioner.yml
@@ -27,7 +27,7 @@ spec:
     helm:
       parameters:
         - name: storageClass.defaultClass
-          value: false
+          value: 'false'
   project: default
   syncPolicy:
     automated:

--- a/kubernetes/argocd/stacks/common/mayastor.yml
+++ b/kubernetes/argocd/stacks/common/mayastor.yml
@@ -16,15 +16,12 @@ metadata:
   name: mayastor
 spec:
   destination:
-    name: ''
     namespace: mayastor
     server: 'https://kubernetes.default.svc'
   source:
-    path: ''
     repoURL: 'https://openebs.github.io/mayastor-extensions'
     targetRevision: 2.2.0
     chart: mayastor
-  sources: []
   project: default
   syncPolicy:
     automated:

--- a/kubernetes/argocd/stacks/common/mayastor.yml
+++ b/kubernetes/argocd/stacks/common/mayastor.yml
@@ -30,3 +30,12 @@ spec:
     automated:
       prune: true
       selfHeal: true
+---
+apiVersion: "openebs.io/v1alpha1"
+kind: DiskPool
+metadata:
+  name: pool-k8s-04
+  namespace: mayastor
+spec:
+  node: k8s-04
+  disks: ["/dev/vda2"]

--- a/kubernetes/argocd/stacks/common/mayastor.yml
+++ b/kubernetes/argocd/stacks/common/mayastor.yml
@@ -26,7 +26,9 @@ spec:
     chart: mayastor
     helm:
       parameters:
-        - name: etcd.persistence.storageClassName
+        - name: etcd.persistence.storageClass
+          value: hostpath
+        - name: loki-stack.loki.persistence.storageClassName
           value: hostpath
   project: default
   syncPolicy:

--- a/kubernetes/argocd/stacks/common/mayastor.yml
+++ b/kubernetes/argocd/stacks/common/mayastor.yml
@@ -14,6 +14,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: mayastor
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   destination:
     namespace: mayastor
@@ -22,6 +24,10 @@ spec:
     repoURL: 'https://openebs.github.io/mayastor-extensions'
     targetRevision: 2.2.0
     chart: mayastor
+    helm:
+      parameters:
+        - name: etcd.persistence.storageClassName
+          value: hostpath
   project: default
   syncPolicy:
     automated:

--- a/kubernetes/argocd/stacks/common/mayastor.yml
+++ b/kubernetes/argocd/stacks/common/mayastor.yml
@@ -38,4 +38,4 @@ metadata:
   namespace: mayastor
 spec:
   node: k8s-04
-  disks: ["/dev/vda2"]
+  disks: ["/dev/vdb"]

--- a/kubernetes/argocd/stacks/common/mayastor.yml
+++ b/kubernetes/argocd/stacks/common/mayastor.yml
@@ -76,6 +76,7 @@ metadata:
   name: mayastor-3
   annotations:
     argocd.argoproj.io/sync-wave: "3"
+    storageclass.kubernetes.io/is-default-class: "true"
 parameters:
   ioTimeout: "30"
   protocol: nvmf

--- a/kubernetes/argocd/stacks/common/mayastor.yml
+++ b/kubernetes/argocd/stacks/common/mayastor.yml
@@ -35,12 +35,49 @@ spec:
     automated:
       prune: true
       selfHeal: true
-#---
-#apiVersion: "openebs.io/v1alpha1"
-#kind: DiskPool
-#metadata:
-#  name: pool-k8s-04
-#  namespace: mayastor
-#spec:
-#  node: k8s-04
-#  disks: ["/dev/vdb"]
+---
+apiVersion: "openebs.io/v1alpha1"
+kind: DiskPool
+metadata:
+  name: pool-k8s-04
+  namespace: mayastor
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  node: k8s-04
+  disks: ["/dev/vdb"]
+---
+apiVersion: "openebs.io/v1alpha1"
+kind: DiskPool
+metadata:
+  name: pool-k8s-05
+  namespace: mayastor
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  node: k8s-05
+  disks: ["/dev/vdb"]
+---
+apiVersion: "openebs.io/v1alpha1"
+kind: DiskPool
+metadata:
+  name: pool-k8s-06
+  namespace: mayastor
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  node: k8s-06
+  disks: ["/dev/vdb"]
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  # This storage class is replicated across 3 nodes
+  name: mayastor-3
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+parameters:
+  ioTimeout: "30"
+  protocol: nvmf
+  repl: "3"
+provisioner: io.openebs.csi-mayastor

--- a/kubernetes/argocd/stacks/common/mayastor.yml
+++ b/kubernetes/argocd/stacks/common/mayastor.yml
@@ -33,12 +33,12 @@ spec:
     automated:
       prune: true
       selfHeal: true
----
-apiVersion: "openebs.io/v1alpha1"
-kind: DiskPool
-metadata:
-  name: pool-k8s-04
-  namespace: mayastor
-spec:
-  node: k8s-04
-  disks: ["/dev/vdb"]
+#---
+#apiVersion: "openebs.io/v1alpha1"
+#kind: DiskPool
+#metadata:
+#  name: pool-k8s-04
+#  namespace: mayastor
+#spec:
+#  node: k8s-04
+#  disks: ["/dev/vdb"]

--- a/kubernetes/argocd/stacks/common/mayastor.yml
+++ b/kubernetes/argocd/stacks/common/mayastor.yml
@@ -2,6 +2,12 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    # The following labels are required to allow Mayastor to use
+    # additional networking and host-level volume operations.
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: mayastor
 ---
 apiVersion: argoproj.io/v1alpha1

--- a/kubernetes/argocd/stacks/common/mayastor.yml
+++ b/kubernetes/argocd/stacks/common/mayastor.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mayastor
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mayastor
+spec:
+  destination:
+    name: ''
+    namespace: mayastor
+    server: 'https://kubernetes.default.svc'
+  source:
+    path: ''
+    repoURL: 'https://openebs.github.io/mayastor-extensions'
+    targetRevision: 2.2.0
+    chart: mayastor
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/kubernetes/argocd/stacks/common/metallb.yml
+++ b/kubernetes/argocd/stacks/common/metallb.yml
@@ -16,15 +16,12 @@ metadata:
   name: metallb
 spec:
   destination:
-    name: ''
     namespace: metallb-system
     server: 'https://kubernetes.default.svc'
   source:
-    path: ''
     repoURL: 'https://charts.bitnami.com/bitnami'
     targetRevision: 4.5.5
     chart: metallb
-  sources: []
   project: default
   syncPolicy:
     automated:

--- a/kubernetes/argocd/stacks/common/traefik.yml
+++ b/kubernetes/argocd/stacks/common/traefik.yml
@@ -12,11 +12,9 @@ metadata:
     argocd.argoproj.io/sync-wave: "1"
 spec:
   destination:
-    name: ''
     namespace: traefik
     server: 'https://kubernetes.default.svc'
   source:
-    path: ''
     repoURL: 'https://traefik.github.io/charts'
     targetRevision: 23.1.0
     chart: traefik
@@ -28,7 +26,6 @@ spec:
             PathPrefix(`/api`)
         - name: ingressRoute.dashboard.entryPoints[0]
           value: web
-  sources: []
   project: default
   syncPolicy:
     automated:


### PR DESCRIPTION
This PR installs [Mayastor](https://openebs.io/docs/concepts/mayastor), a distributed block storage data platform. This allows applications running on the cluster to have data replication and to allow rescheduling across nodes without replying on external servers.

As a dependency of Mayastor, a `hostpath` storage class and dynamic provisioner was added. (Helm chart: https://artifacthub.io/packages/helm/rimusz/hostpath-provisioner)

Additional storage devices have also been added to the worker nodes to accommodate the block storage data platform requirements. These additional storage devices are located on local hypervisor storage instead of on the acm-nfs.

### Known Issues

- The initial provisioning of Mayastor requires a prior working storage class. By default, the cluster does not have this, so in addition to Mayastor, a `hostpath` [dynamic volume provisioner](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) was also installed. This storageclass was temporarily set as the default `storageclass` during the provisioning of Mayastor.
- The `diskpool` kind is installed during the CSI provisioning and is not available until Mayastor has become healthy. Due to this, the `diskpool` resources may fail during initial deployment. The `sync-wave` annotation was added to maintain some ordering to deployments. Since the csi provisioner setup happens outside of the deployment, the `diskpool` kind may not be defined when ArgoCD attempts to deploy the resources causing the deployment to fail. It should eventually succeed if retries are attempted.