### PR TITLE
🐛 Bug/Vault TLS

### DIFF
--- a/kubernetes/argocd/stacks/common/vault-values-override.yml
+++ b/kubernetes/argocd/stacks/common/vault-values-override.yml
@@ -31,19 +31,19 @@ server:
         storage "raft" {
           path = "/vault/data"
             retry_join {
-            leader_api_addr = "https://vault-0.vault:8200"
+            leader_api_addr = "https://vault-0.vault-internal:8200"
             leader_ca_cert_file = "/vault/userconfig/vault-ha-tls/vault.ca"
             leader_client_cert_file = "/vault/userconfig/vault-ha-tls/vault.crt"
             leader_client_key_file = "/vault/userconfig/vault-ha-tls/vault.key"
           }
           retry_join {
-            leader_api_addr = "https://vault-1.vault:8200"
+            leader_api_addr = "https://vault-1.vault-internal:8200"
             leader_ca_cert_file = "/vault/userconfig/vault-ha-tls/vault.ca"
             leader_client_cert_file = "/vault/userconfig/vault-ha-tls/vault.crt"
             leader_client_key_file = "/vault/userconfig/vault-ha-tls/vault.key"
           }
           retry_join {
-            leader_api_addr = "https://vault-2.vault:8200"
+            leader_api_addr = "https://vault-2.vault-internal:8200"
             leader_ca_cert_file = "/vault/userconfig/vault-ha-tls/vault.ca"
             leader_client_cert_file = "/vault/userconfig/vault-ha-tls/vault.crt"
             leader_client_key_file = "/vault/userconfig/vault-ha-tls/vault.key"

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -111,3 +111,33 @@ subjects:
   - kind: ServiceAccount
     name: vault-auth
     namespace: default
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: vault
+  namespace: vault
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - kind: Rule
+    match: Host(`vault.acmuic.org`)
+    priority: 10
+    services:
+    - kind: Service
+      name: vault-ui
+      namespace: vault
+      passHostHeader: true
+      port: 8200
+      responseForwarding:
+        flushInterval: 1ms
+      scheme: https
+      sticky:
+        cookie:
+          httpOnly: true
+          name: cookie
+          secure: true
+          sameSite: none
+      strategy: RoundRobin
+      weight: 10

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -128,7 +128,7 @@ spec:
     - kind: Service
       name: vault-ui
       namespace: vault
-      passHostHeader: true
+      passHostHeader: false
       port: 8200
       responseForwarding:
         flushInterval: 1ms


### PR DESCRIPTION
This fixes an issue with Vault not being able to communicate between nodes. Also switching to passing external traffic through Traefik to ensure the internal certificates aren't being exposed. This may need additional work to make ingress -> service communication work.