### PR TITLE
update typesense federated creds subject for main branch

### DIFF
--- a/azure/terraform/stacks/typesense/service_principal.tf
+++ b/azure/terraform/stacks/typesense/service_principal.tf
@@ -37,7 +37,7 @@ resource "azuread_application_federated_identity_credential" "terraform_typesens
   description           = "https://github.com/acm-uic/acm-uic.github.io"
   audiences             = ["api://AzureADTokenExchange"]
   issuer                = "https://token.actions.githubusercontent.com"
-  subject               = "repo:acm-uic/acm-uic.github.io:ref:main"
+  subject               = "repo:acm-uic/acm-uic.github.io:ref:refs/heads/main"
 }
 
 resource "azuread_application_federated_identity_credential" "terraform_typesense_deploy_pr" {


### PR DESCRIPTION
Update typesense federated credentials for github actions running on main branch of acm-uic/acm-uic.github.io
Error:
```
Error: : AADSTS70021: No matching federated identity record found for presented assertion. Assertion Issuer: 'https://token.actions.githubusercontent.com/'. Assertion Subject: 'repo:acm-uic/acm-uic.github.io:ref:refs/heads/main'. Assertion Audience: 'api://AzureADTokenExchange'. https://docs.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation
```