### PR TITLE
🐞 Bug/trust-issues: Updating the allowed usage of the CA

### DIFF
--- a/kubernetes/argocd/stacks/common/cert-manager/self-ca.yml
+++ b/kubernetes/argocd/stacks/common/cert-manager/self-ca.yml
@@ -17,6 +17,9 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
+  usages:
+    - server auth
+    - client auth
   issuerRef:
     name: selfsigned-issuer-donotuse
     kind: ClusterIssuer
@@ -35,7 +38,8 @@ kind: Certificate
 metadata:
   name: test-cert
 spec:
-  commonName: test.acmuic.org
+  dnsNames:
+    - test.acmuic.org
   secretName: test-cert
   issuerRef:
     kind: ClusterIssuer


### PR DESCRIPTION
This PR updates the self-signed CA with a different allowed usage policy.

Originally, our CA had the following usages:

<details><summary>See full cert description (click here)</summary>
<code>
$ openssl x509 -in ~/Downloads/acm-ca.crt -text -noout
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            66:64:7b:af:b1:18:4a:1d:52:44:70:04:46:d0:31:34
        Signature Algorithm: ecdsa-with-SHA256
        Issuer: CN = acmuic-self-ca
        Validity
            Not Before: Jul 26 17:30:14 2023 GMT
            Not After : Jul 23 17:30:14 2033 GMT
        Subject: CN = acmuic-self-ca
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:e2:18:87:7d:bb:fd:6f:62:d0:20:0d:c2:6a:d1:
                    d4:ee:c3:71:69:d1:72:d7:cd:18:db:74:9f:d3:e4:
                    67:d7:29:e3:76:99:41:ac:e4:99:a1:74:0c:16:bf:
                    f3:e2:f6:f1:59:5a:24:9a:b6:21:69:c5:f2:53:da:
                    11:32:6e:08:91
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment, Certificate Sign
            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Subject Key Identifier:
                E9:51:CA:E8:ED:20:43:AA:3D:88:B4:EF:F1:14:B0:03:AD:56:8C:3F
    Signature Algorithm: ecdsa-with-SHA256
    Signature Value:
        30:45:02:20:73:76:1d:e6:88:7e:e2:c4:24:3e:82:08:50:bf:
        18:c9:6e:c0:a0:10:5f:76:f3:bc:e7:0e:07:2d:40:af:43:c2:
        02:21:00:8c:63:09:b4:88:f4:5f:c9:38:65:6d:b6:2f:06:ab:
        e2:96:a8:89:cd:17:b1:fc:5a:0d:42:c6:05:cf:7b:d2:d2
</code>
</details> 

```
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment, Certificate Sign
            X509v3 Basic Constraints: critical
                CA:TRUE
```

After this change, the CA will be updated to have the following usages:
```
X509v3 extensions:
            X509v3 Key Usage: critical
                Certificate Sign
            X509v3 Extended Key Usage:
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Basic Constraints: critical
                CA:TRUE
```

According to the [OpenSSL documentation](https://www.openssl.org/docs/manmaster/man5/x509v3_config.html), extended key usage is defined as follows:
> This extension consists of a list of values indicating purposes for which the certificate public key can be used.

This description seems to be a bit ambiguous as to whether the key usages need to be defined in the intermediate certificates in addition to the leaf certificate OR if it is just needed in the intermediate certificate. Through testing, it appears that the ladder is true at least in the Firefox and CURL implementations. (i.e.: The certificate issuing the leaf certificate needs to have the key usage defined that the leaf certificate is intended for. The leaf certificate itself does not need any additional key usage aside from `Digital Signature` and `Key Encipherment` in the common case of a web server TLS connection.)

In this case, we may want to consider adding additional key usages to the CA if we anticipate any additional usages for the future issued leaf certificates. :thinking: 