### PR TITLE
⬆️ Feature/ArgoCD-upgrade-2.7.9: Upgrading ArgoCD to 2.7.9

### DIFF
--- a/kubernetes/terraform/stacks/1_k8s_cluster_setup/argocd.tf
+++ b/kubernetes/terraform/stacks/1_k8s_cluster_setup/argocd.tf
@@ -32,8 +32,8 @@ resource "helm_release" "argocd" {
   }
 
   set {
-    name  = "configs.params.server\\.insecure"
-    value = "true"
+    name  = "server.service.type"
+    value = "LoadBalancer"
   }
 
 }

--- a/kubernetes/terraform/stacks/1_k8s_cluster_setup/configurations/acmapp_prod.tfvars
+++ b/kubernetes/terraform/stacks/1_k8s_cluster_setup/configurations/acmapp_prod.tfvars
@@ -3,4 +3,4 @@ public_domain_suffixes = ["acmuic.org"]
 external_dns_chart_version = "1.13.0"
 external_dns_provider = "azure"
 azure_dns_resource_group = "acm-general"
-argocd_chart_version = "5.37.1"
+argocd_chart_version = "5.42.0"


### PR DESCRIPTION
This upgrades ArgoCD to 2.7.9. Previous version was 2.7.7.

Release Notes: 
- https://github.com/argoproj/argo-cd/releases/tag/v2.7.9
- https://github.com/argoproj/argo-cd/releases/tag/v2.7.8