### PR TITLE
⬆️ Feature/ArgoCD-upgrade-2.8.0: Upgrading ArgoCD to 2.8.0

### DIFF
--- a/kubernetes/terraform/stacks/1_k8s_cluster_setup/configurations/acmapp_prod.tfvars
+++ b/kubernetes/terraform/stacks/1_k8s_cluster_setup/configurations/acmapp_prod.tfvars
@@ -3,4 +3,4 @@ public_domain_suffixes = ["acmuic.org"]
 external_dns_chart_version = "1.13.0"
 external_dns_provider = "azure"
 azure_dns_resource_group = "acm-general"
-argocd_chart_version = "5.42.0"
+argocd_chart_version = "5.43.4"


### PR DESCRIPTION
This upgrades ArgoCD to 2.8.0. Previous version was 2.7.9.

Release Notes:

- https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.7-2.8/
- https://github.com/argoproj/argo-cd/releases/tag/v2.8.0
- https://github.com/argoproj/argo-cd/releases/tag/v2.7.9


