### PR TITLE
🔒Feature/vault certs

### DIFF
--- a/kubernetes/argocd/stacks/common/traefik.yml
+++ b/kubernetes/argocd/stacks/common/traefik.yml
@@ -26,6 +26,8 @@ spec:
             PathPrefix(`/api`)
         - name: ingressRoute.dashboard.entryPoints[0]
           value: web
+        - name: logs.general.level
+          value: DEBUG
   project: default
   syncPolicy:
     automated:

--- a/kubernetes/argocd/stacks/common/traefik.yml
+++ b/kubernetes/argocd/stacks/common/traefik.yml
@@ -26,8 +26,6 @@ spec:
             PathPrefix(`/api`)
         - name: ingressRoute.dashboard.entryPoints[0]
           value: web
-        - name: logs.general.level
-          value: DEBUG
   project: default
   syncPolicy:
     automated:

--- a/kubernetes/argocd/stacks/common/vault-values-override.yml
+++ b/kubernetes/argocd/stacks/common/vault-values-override.yml
@@ -49,6 +49,7 @@ server:
             leader_client_key_file = "/vault/userconfig/vault-ha-tls/tls.key"
           }
         }
+        log_level = "Debug"
   resources:
     requests:
       memory: 2Gi

--- a/kubernetes/argocd/stacks/common/vault-values-override.yml
+++ b/kubernetes/argocd/stacks/common/vault-values-override.yml
@@ -23,30 +23,30 @@ server:
         listener "tcp" {
           address = "[::]:8200"
           cluster_address = "[::]:8201"
-          tls_cert_file = "/vault/userconfig/vault-ha-tls/vault.crt"
-          tls_key_file = "/vault/userconfig/vault-ha-tls/vault.key"
-          tls_client_ca_file = "/vault/userconfig/vault-ha-tls/vault.ca"
+          tls_cert_file = "/vault/userconfig/vault-ha-tls/tls.crt"
+          tls_key_file = "/vault/userconfig/vault-ha-tls/tls.key"
+          tls_client_ca_file = "/vault/userconfig/vault-ha-tls/ca.crt"
         }
 
         storage "raft" {
           path = "/vault/data"
             retry_join {
             leader_api_addr = "https://vault-0.vault-internal:8200"
-            leader_ca_cert_file = "/vault/userconfig/vault-ha-tls/vault.ca"
-            leader_client_cert_file = "/vault/userconfig/vault-ha-tls/vault.crt"
-            leader_client_key_file = "/vault/userconfig/vault-ha-tls/vault.key"
+            leader_ca_cert_file = "/vault/userconfig/vault-ha-tls/ca.crt"
+            leader_client_cert_file = "/vault/userconfig/vault-ha-tls/tls.crt"
+            leader_client_key_file = "/vault/userconfig/vault-ha-tls/tls.key"
           }
           retry_join {
             leader_api_addr = "https://vault-1.vault-internal:8200"
-            leader_ca_cert_file = "/vault/userconfig/vault-ha-tls/vault.ca"
-            leader_client_cert_file = "/vault/userconfig/vault-ha-tls/vault.crt"
-            leader_client_key_file = "/vault/userconfig/vault-ha-tls/vault.key"
+            leader_ca_cert_file = "/vault/userconfig/vault-ha-tls/ca.crt"
+            leader_client_cert_file = "/vault/userconfig/vault-ha-tls/tls.crt"
+            leader_client_key_file = "/vault/userconfig/vault-ha-tls/tls.key"
           }
           retry_join {
             leader_api_addr = "https://vault-2.vault-internal:8200"
-            leader_ca_cert_file = "/vault/userconfig/vault-ha-tls/vault.ca"
-            leader_client_cert_file = "/vault/userconfig/vault-ha-tls/vault.crt"
-            leader_client_key_file = "/vault/userconfig/vault-ha-tls/vault.key"
+            leader_ca_cert_file = "/vault/userconfig/vault-ha-tls/ca.crt"
+            leader_client_cert_file = "/vault/userconfig/vault-ha-tls/tls.crt"
+            leader_client_key_file = "/vault/userconfig/vault-ha-tls/tls.key"
           }
         }
   resources:
@@ -67,9 +67,9 @@ server:
   standalone:
     enabled: false
   extraEnvironmentVars:
-    VAULT_CACERT: "/vault/userconfig/vault-ha-tls/vault.ca"
-    VAULT_TLSCERT: "/vault/userconfig/vault-ha-tls/vault.crt"
-    VAULT_TLSKEY: "/vault/userconfig/vault-ha-tls/vault.key"
+    VAULT_CACERT: "/vault/userconfig/vault-ha-tls/ca.crt"
+    VAULT_TLSCERT: "/vault/userconfig/vault-ha-tls/tls.crt"
+    VAULT_TLSKEY: "/vault/userconfig/vault-ha-tls/tls.key"
   volumes:
     - name: userconfig-vault-ha-tls
       secret:

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -127,7 +127,6 @@ spec:
     dialTimeout: 42s
     responseHeaderTimeout: 42s
     idleConnTimeout: 42s
-  peerCertURI: "https://vault.acmuic.org"
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -112,6 +112,23 @@ subjects:
     name: vault-auth
     namespace: default
 ---
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: vaulttransport
+  namespace: vault
+spec:
+  serverName: "vault-ui.vault"
+  insecureSkipVerify: true
+  rootCAsSecrets:
+    - vault-ha-tls
+  maxIdleConnsPerHost: 1
+  forwardingTimeouts:
+    dialTimeout: 42s
+    responseHeaderTimeout: 42s
+    idleConnTimeout: 42s
+  peerCertURI: "vault-ui.vault"
+---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
@@ -133,6 +150,7 @@ spec:
       responseForwarding:
         flushInterval: 1ms
       scheme: https
+      serversTransport: vaulttransport
       sticky:
         cookie:
           httpOnly: true

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -127,7 +127,7 @@ spec:
     dialTimeout: 42s
     responseHeaderTimeout: 42s
     idleConnTimeout: 42s
-  peerCertURI: "vault.acmuic.org"
+  peerCertURI: "https://vault.acmuic.org"
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -128,7 +128,7 @@ spec:
     - kind: Service
       name: vault-ui
       namespace: vault
-      passHostHeader: false
+      passHostHeader: true
       port: 8200
       responseForwarding:
         flushInterval: 1ms
@@ -143,7 +143,6 @@ spec:
       weight: 10
   tls:
     secretName: vault-ha-tls
-    passthrough: true
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -22,13 +22,9 @@ spec:
       valueFiles:
         - values.yaml
         - $values/kubernetes/argocd/stacks/common/vault-values-override.yml
-        - $values2/kubernetes/argocd/stacks/common/vault-values-override.yml
-  - repoURL: 'git@github.com:acm-uic/IaC.git'
-    targetRevision: 'HEAD'
-    ref: values
   - repoURL: 'git@github.com:acm-uic/IaC.git'
     targetRevision: 'feature/vault-certs'
-    ref: values2
+    ref: values
   project: default
   syncPolicy:
     automated:

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -143,6 +143,7 @@ spec:
       weight: 10
   tls:
     secretName: vault-ha-tls
+    passthrough: true
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -153,7 +153,6 @@ spec:
       serversTransport: vaulttransport
       strategy: RoundRobin
       weight: 10
-      nativeLB: false
   tls:
     secretName: vault-ha-tls
 ---

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -151,12 +151,6 @@ spec:
         flushInterval: 1ms
       scheme: https
       serversTransport: vaulttransport
-      sticky:
-        cookie:
-          httpOnly: true
-          name: cookie
-          secure: true
-          sameSite: none
       strategy: RoundRobin
       weight: 10
   tls:

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -141,6 +141,8 @@ spec:
           sameSite: none
       strategy: RoundRobin
       weight: 10
+  tls:
+    secretName: vault-ha-tls
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -141,3 +141,26 @@ spec:
           sameSite: none
       strategy: RoundRobin
       weight: 10
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: vault-raft-cert
+  namespace: vault
+spec:
+  dnsNames:
+    - "vault.acmuic.org"
+    - "*.vault.svc.cluster.local"
+    - "*.vault-internal"
+    - "*.vault-internal.vault.svc.cluster.local"
+    - "*.vault"
+  ipAddresses:
+    - 127.0.0.1
+  usages:
+    - server auth
+    - digital signature
+    - key encipherment
+  secretName: vault-ha-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: acmuic-self-ca

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -22,9 +22,13 @@ spec:
       valueFiles:
         - values.yaml
         - $values/kubernetes/argocd/stacks/common/vault-values-override.yml
+        - $values2/kubernetes/argocd/stacks/common/vault-values-override.yml
   - repoURL: 'git@github.com:acm-uic/IaC.git'
     targetRevision: 'HEAD'
     ref: values
+  - repoURL: 'git@github.com:acm-uic/IaC.git'
+    targetRevision: 'feature/vault-certs'
+    ref: values2
   project: default
   syncPolicy:
     automated:

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -118,7 +118,7 @@ metadata:
   name: vaulttransport
   namespace: vault
 spec:
-  serverName: "vault-ui.vault"
+  serverName: "vault.acmuic.org"
   insecureSkipVerify: true
   rootCAsSecrets:
     - vault-ha-tls
@@ -127,7 +127,7 @@ spec:
     dialTimeout: 42s
     responseHeaderTimeout: 42s
     idleConnTimeout: 42s
-  peerCertURI: "vault-ui.vault"
+  peerCertURI: "vault.acmuic.org"
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -153,6 +153,7 @@ spec:
       serversTransport: vaulttransport
       strategy: RoundRobin
       weight: 10
+      nativeLB: false
   tls:
     secretName: vault-ha-tls
 ---


### PR DESCRIPTION
- This PR updates the certificate used by Vault nodes. The certificate is now generated by `cert-manager`. 
- This initially self-signed certificate is used for inter-pod communication.
- This also updates the Traefik ingress to correctly use these certificates for TLS terminate between the ingress and the vault service. (We were previously getting bad handshake errors because the ingress client did not trust the self-signed ca.)