### PR TITLE
🌐 Feature/Externaldns

### DIFF
--- a/azure/terraform/stacks/acm-general/external-dns.tf
+++ b/azure/terraform/stacks/acm-general/external-dns.tf
@@ -31,8 +31,20 @@ resource "azurerm_role_assignment" "externaldns_contributor" {
   principal_id         = azuread_service_principal.externaldns.object_id
 }
 
+output "tenant_id" {
+  value = data.azuread_client_config.current.tenant_id
+}
+
+output "subscription_id" {
+  value = data.azurerm_subscription.current.subscription_id
+}
+
 output "externaldns_sp_keyid" {
   value = azuread_service_principal_password.externaldns.key_id
+}
+
+output "externaldns_sp_appid" {
+  value = azuread_application.externaldns.application_id
 }
 
 output "externaldns_sp_password" {

--- a/azure/terraform/stacks/acm-general/external-dns.tf
+++ b/azure/terraform/stacks/acm-general/external-dns.tf
@@ -53,5 +53,5 @@ output "externaldns_sp_password" {
 }
 
 output "default_resource_group" {
-  value     = var.resource_group_name
+  value = var.resource_group_name
 }

--- a/azure/terraform/stacks/acm-general/external-dns.tf
+++ b/azure/terraform/stacks/acm-general/external-dns.tf
@@ -20,13 +20,13 @@ resource "azuread_service_principal_password" "externaldns" {
 }
 
 resource "azurerm_role_assignment" "externaldns_reader" {
-  scope                = "/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/acm-general/providers/Microsoft.Network/dnszones/${var.public_domain_suffixes[0]}"
+  scope                = "/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/${var.resource_group_name}/providers/Microsoft.Network/dnszones/${var.public_domain_suffixes[0]}"
   role_definition_name = "Reader"
   principal_id         = azuread_service_principal.externaldns.object_id
 }
 
 resource "azurerm_role_assignment" "externaldns_contributor" {
-  scope                = "/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/acm-general/providers/Microsoft.Network/dnszones/${var.public_domain_suffixes[0]}"
+  scope                = "/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/${var.resource_group_name}/providers/Microsoft.Network/dnszones/${var.public_domain_suffixes[0]}"
   role_definition_name = "Contributor"
   principal_id         = azuread_service_principal.externaldns.object_id
 }
@@ -50,4 +50,8 @@ output "externaldns_sp_appid" {
 output "externaldns_sp_password" {
   value     = azuread_service_principal_password.externaldns.value
   sensitive = true
+}
+
+output "default_resource_group" {
+  value     = var.resource_group_name
 }

--- a/azure/terraform/stacks/acm-general/variables.tf
+++ b/azure/terraform/stacks/acm-general/variables.tf
@@ -21,3 +21,9 @@ variable "external_dns_namespace" {
   default     = "externaldns"
 }
 
+variable "resource_group_name" {
+  type        = string
+  description = "Specifies the name of the resource group that resources should be deployed into"
+  default     = "acm-general"
+
+}

--- a/azure/terraform/stacks/vault-injector/external_dns.tf
+++ b/azure/terraform/stacks/vault-injector/external_dns.tf
@@ -5,7 +5,7 @@ resource "vault_kv_secret_v2" "externaldns_keyid" {
   {
     aadClientId = data.terraform_remote_state.acm_general.outputs.externaldns_sp_appid,
     aadClientSecret = data.terraform_remote_state.acm_general.outputs.externaldns_sp_password
-    resourceGroup = "acm-general"
+    resourceGroup = data.terraform_remote_state.acm_general.outputs.default_resource_group
     subscriptionId = data.terraform_remote_state.acm_general.outputs.subscription_id
     tenantId = data.terraform_remote_state.acm_general.outputs.tenant_id
   }

--- a/azure/terraform/stacks/vault-injector/external_dns.tf
+++ b/azure/terraform/stacks/vault-injector/external_dns.tf
@@ -3,8 +3,11 @@ resource "vault_kv_secret_v2" "externaldns_keyid" {
   name                       = "externaldns/service_account"
   data_json                  = jsonencode(
   {
-    key_id = data.terraform_remote_state.acm_general.outputs.externaldns_sp_keyid,
-    key_secret = data.terraform_remote_state.acm_general.outputs.externaldns_sp_password
+    aadClientId = data.terraform_remote_state.acm_general.outputs.externaldns_sp_appid,
+    aadClientSecret = data.terraform_remote_state.acm_general.outputs.externaldns_sp_password
+    resourceGroup = "acm-general"
+    subscriptionId = data.terraform_remote_state.acm_general.outputs.subscription_id
+    tenantId = data.terraform_remote_state.acm_general.outputs.tenant_id
   }
   )
   custom_metadata {

--- a/azure/terraform/stacks/vault-injector/external_dns.tf
+++ b/azure/terraform/stacks/vault-injector/external_dns.tf
@@ -1,19 +1,19 @@
 resource "vault_kv_secret_v2" "externaldns_keyid" {
-  mount                      = "kv"
-  name                       = "externaldns/service_account"
-  data_json                  = jsonencode(
-  {
-    aadClientId = data.terraform_remote_state.acm_general.outputs.externaldns_sp_appid,
-    aadClientSecret = data.terraform_remote_state.acm_general.outputs.externaldns_sp_password
-    resourceGroup = data.terraform_remote_state.acm_general.outputs.default_resource_group
-    subscriptionId = data.terraform_remote_state.acm_general.outputs.subscription_id
-    tenantId = data.terraform_remote_state.acm_general.outputs.tenant_id
-  }
+  mount = "kv"
+  name  = "externaldns/service_account"
+  data_json = jsonencode(
+    {
+      aadClientId     = data.terraform_remote_state.acm_general.outputs.externaldns_sp_appid,
+      aadClientSecret = data.terraform_remote_state.acm_general.outputs.externaldns_sp_password
+      resourceGroup   = data.terraform_remote_state.acm_general.outputs.default_resource_group
+      subscriptionId  = data.terraform_remote_state.acm_general.outputs.subscription_id
+      tenantId        = data.terraform_remote_state.acm_general.outputs.tenant_id
+    }
   )
   custom_metadata {
     data = {
       managed_by = "Terraform",
-      repo = "IaC/azure/terraform/stacks/vault-injector"
+      repo       = "IaC/azure/terraform/stacks/vault-injector"
     }
   }
 }

--- a/azure/terraform/stacks/vault-injector/main.tf
+++ b/azure/terraform/stacks/vault-injector/main.tf
@@ -1,5 +1,5 @@
 data "terraform_remote_state" "acm_general" {
-  backend = "azurerm"
+  backend   = "azurerm"
   workspace = "prod"
 
   config = {

--- a/azure/terraform/stacks/vault-injector/providers.tf
+++ b/azure/terraform/stacks/vault-injector/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "1.5.2"
   required_providers {
     vault = {
-      source = "hashicorp/vault"
+      source  = "hashicorp/vault"
       version = "3.19.0"
     }
   }

--- a/kubernetes/argocd/stacks/common/argo_repos.yml
+++ b/kubernetes/argocd/stacks/common/argo_repos.yml
@@ -87,7 +87,21 @@ kind: Secret
 metadata:
   name: jetstack
   namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
 stringData:
   name: jetstack
   url: https://charts.jetstack.io
+  type: helm
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-dns
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  name: external-dns
+  url: https://kubernetes-sigs.github.io/external-dns/
   type: helm

--- a/kubernetes/argocd/stacks/common/externaldns.yml
+++ b/kubernetes/argocd/stacks/common/externaldns.yml
@@ -17,7 +17,7 @@ spec:
   sources:
     - repoURL: 'https://kubernetes-sigs.github.io/external-dns/'
       targetRevision: 1.13.0
-      chart: externaldns
+      chart: external-dns
       helm:
         valueFiles:
           - $values/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml

--- a/kubernetes/argocd/stacks/common/externaldns.yml
+++ b/kubernetes/argocd/stacks/common/externaldns.yml
@@ -46,7 +46,7 @@ spec:
     - server auth
     - digital signature
     - key encipherment
-  secretName: vault-ha-tls
+  secretName: externaldns-vault-cert
   issuerRef:
     kind: ClusterIssuer
     name: acmuic-self-ca

--- a/kubernetes/argocd/stacks/common/externaldns.yml
+++ b/kubernetes/argocd/stacks/common/externaldns.yml
@@ -30,3 +30,23 @@ spec:
     automated:
       prune: true
       selfHeal: true
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: externaldns-vault-cert
+  namespace: externaldns
+spec:
+  dnsNames:
+    - "externaldns.acmuic.org"
+    - "*.externaldns.svc"
+  ipAddresses:
+    - 127.0.0.1
+  usages:
+    - server auth
+    - digital signature
+    - key encipherment
+  secretName: vault-ha-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: acmuic-self-ca

--- a/kubernetes/argocd/stacks/common/externaldns.yml
+++ b/kubernetes/argocd/stacks/common/externaldns.yml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: externaldns
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: externaldns
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  destination:
+    namespace: externaldns
+    server: 'https://kubernetes.default.svc'
+  source:
+    repoURL: 'https://kubernetes-sigs.github.io/external-dns/'
+    targetRevision: 1.13.0
+    chart: externaldns
+    helm:
+      parameters:
+        - name: provider
+          value: azure
+        - name: serviceAccount.name
+          value: externaldns
+        - name: secretConfiguration.enabled
+          value: "true"
+        - name: secretConfiguration.mountPath
+          value: "/etc/kubernetes"
+        - name: secretConfiguration.subPath
+          value: "azure.json"
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/kubernetes/argocd/stacks/common/externaldns.yml
+++ b/kubernetes/argocd/stacks/common/externaldns.yml
@@ -14,22 +14,17 @@ spec:
   destination:
     namespace: externaldns
     server: 'https://kubernetes.default.svc'
-  source:
-    repoURL: 'https://kubernetes-sigs.github.io/external-dns/'
-    targetRevision: 1.13.0
-    chart: externaldns
-    helm:
-      parameters:
-        - name: provider
-          value: azure
-        - name: serviceAccount.name
-          value: externaldns
-        - name: secretConfiguration.enabled
-          value: "true"
-        - name: secretConfiguration.mountPath
-          value: "/etc/kubernetes"
-        - name: secretConfiguration.subPath
-          value: "azure.json"
+  sources:
+    - repoURL: 'https://kubernetes-sigs.github.io/external-dns/'
+      targetRevision: 1.13.0
+      chart: externaldns
+      helm:
+        valueFiles:
+          - $values/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml
+    - repoURL: 'git@github.com:acm-uic/IaC.git'
+      targetRevision: feature/externaldns
+      ref: values
+
   project: default
   syncPolicy:
     automated:

--- a/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml
+++ b/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml
@@ -1,0 +1,16 @@
+---
+provider: azure
+serviceAccount:
+  name: externaldns
+secretConfiguration:
+  enabled: true
+  mountPath: "/etc/kubernetes"
+  subPath: "azure.json"
+  data: |
+    {
+      "tenantId" : "tenant",
+      "subscriptionId" : "subscription",
+      "resourceGroup" : "azure resource group",
+      "aadClientId" : "app sp id",
+      "aadClientSecret" : "app sp secret"
+    }

--- a/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml
+++ b/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml
@@ -4,6 +4,7 @@ serviceAccount:
   name: externaldns
 podAnnotations:
   vault.hashicorp.com/agent-inject: 'true'
+  vault.hashicorp.com/role: 'externaldns'
   vault.hashicorp.com/agent-inject-secret-azure.json: 'kv/externaldns/service_account'
   vault.hashicorp.com/agent-inject-template-azure.json: |
     {{- with secret "kv/externaldns/service_account" -}}

--- a/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml
+++ b/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml
@@ -2,15 +2,17 @@
 provider: azure
 serviceAccount:
   name: externaldns
-secretConfiguration:
-  enabled: true
-  mountPath: "/etc/kubernetes"
-  subPath: "azure.json"
-  data: |
+podAnnotations:
+  vault.hashicorp.com/agent-inject: 'true'
+  vault.hashicorp.com/agent-inject-secret-azure.json: 'kv/externaldns/service_account'
+  vault.hashicorp.com/agent-inject-template-azure.json: |
+    {{- with secret "kv/externaldns/service_account" -}}
     {
-      "tenantId" : "tenant",
-      "subscriptionId" : "subscription",
-      "resourceGroup" : "azure resource group",
-      "aadClientId" : "app sp id",
-      "aadClientSecret" : "app sp secret"
+      "tenantId" : "{{ .Data.data.tenantId }}",
+      "subscriptionId" : "{{ .Data.data.subscriptionId }}",
+      "resourceGroup" : "{{ .Data.data.resourceGroup }}",
+      "aadClientId" : "{{ .Data.data.aadClientId }}",
+      "aadClientSecret" : "{{ .Data.data.aadClientSecret }}"
     }
+    {{- end }}
+extraArgs: ["--azure-config-file=/vault/secrets/azure.json"]

--- a/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml
+++ b/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml
@@ -6,7 +6,7 @@ podAnnotations:
   vault.hashicorp.com/agent-inject: 'true'
   vault.hashicorp.com/role: 'externaldns'
   vault.hashicorp.com/agent-inject-secret-azure.json: 'kv/externaldns/service_account'
-  vault.hashicorp.com/ca-cert: "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+  vault.hashicorp.com/tls-secret: 'externaldns-vault-cert'
   vault.hashicorp.com/agent-inject-template-azure.json: |
     {{- with secret "kv/externaldns/service_account" -}}
     {

--- a/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml
+++ b/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml
@@ -7,6 +7,7 @@ podAnnotations:
   vault.hashicorp.com/role: 'externaldns'
   vault.hashicorp.com/agent-inject-secret-azure.json: 'kv/externaldns/service_account'
   vault.hashicorp.com/tls-secret: 'externaldns-vault-cert'
+  vault.hashicorp.com/ca-cert: '/vault/tls/ca.crt'
   vault.hashicorp.com/agent-inject-template-azure.json: |
     {{- with secret "kv/externaldns/service_account" -}}
     {

--- a/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml
+++ b/kubernetes/argocd/stacks/common/helm-values/externaldns-values.yml
@@ -6,6 +6,7 @@ podAnnotations:
   vault.hashicorp.com/agent-inject: 'true'
   vault.hashicorp.com/role: 'externaldns'
   vault.hashicorp.com/agent-inject-secret-azure.json: 'kv/externaldns/service_account'
+  vault.hashicorp.com/ca-cert: "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
   vault.hashicorp.com/agent-inject-template-azure.json: |
     {{- with secret "kv/externaldns/service_account" -}}
     {

--- a/kubernetes/argocd/stacks/common/vault-values-override.yml
+++ b/kubernetes/argocd/stacks/common/vault-values-override.yml
@@ -80,6 +80,7 @@ server:
       - mountPath: /vault/userconfig/vault-ha-tls
         name: userconfig-vault-ha-tls
         readOnly: true
+  logLevel: debug
 
 ui:
   enabled: true

--- a/kubernetes/argocd/stacks/common/vault-values-override.yml
+++ b/kubernetes/argocd/stacks/common/vault-values-override.yml
@@ -80,7 +80,6 @@ server:
       - mountPath: /vault/userconfig/vault-ha-tls
         name: userconfig-vault-ha-tls
         readOnly: true
-  logLevel: debug
 
 ui:
   enabled: true

--- a/kubernetes/argocd/stacks/common/vault.yml
+++ b/kubernetes/argocd/stacks/common/vault.yml
@@ -167,6 +167,7 @@ spec:
     - "*.vault-internal"
     - "*.vault-internal.vault.svc.cluster.local"
     - "*.vault"
+    - "*.vault.svc"
   ipAddresses:
     - 127.0.0.1
   usages:


### PR DESCRIPTION
This installs and configures ExternalDNS on the Kubernetes cluster.

Changes were made to the Terraform stacks to:
- Output the created ExternalDNS information
- Inject the configuration data into Vault

Notable changes to the default ExternalDNS helm chart:
- The Vault injector was used to place credentials into the container dynamically via a sidecar
- Annotations were added to the pod definition to allow the Vault Injector to do its work
- A dummy certificate(`externaldns-vault-cert`) was generated to allow the vault-injector access to the Vault endpoint. Using a dummy cert allows us to not expose key information from the Vault/cert-manager namespace.

Notable changes to the Vault deployment:
- The main Vault certificate was updated to accommodate internal service traffic between namespaces (vault ↔️ externaldns)