### PR TITLE
Use AAD federated auth for azure login

### DIFF
--- a/.github/workflows/azure_terraform_apply.yml
+++ b/.github/workflows/azure_terraform_apply.yml
@@ -5,16 +5,22 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/azure_terraform_apply.yml'
       - 'azure/terraform/stacks/**'
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
 
 jobs:
   terraform:
     name: 'Terraform Apply'
     env:
       ARM_CLIENT_ID: ${{ secrets.AZURE_AD_CLIENT_ID }}
-      ARM_CLIENT_SECRET: ${{ secrets.AZURE_AD_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
+      ARM_USE_OIDC: true
       TF_WORKSPACE: prod
       TF_IN_AUTOMATION: true
       TF_INPUT: 0
@@ -33,7 +39,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Azure CLI setup
+        uses: azure/login@v1
+        with:
+          client-id: ${{ env.ARM_CLIENT_ID }}
+          tenant-id: ${{ env.ARM_TENANT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
 
       - name: 'Terraform Format'
         id: fmt

--- a/.github/workflows/azure_terraform_plan.yml
+++ b/.github/workflows/azure_terraform_plan.yml
@@ -3,16 +3,22 @@ name: 'Terraform PRs for Azure'
 on:
   pull_request:
     paths:
+      - '.github/workflows/azure_terraform_plan.yml'
       - 'azure/terraform/stacks/**'
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
 
 jobs:
   terraform:
     name: 'Terraform PR Plan'
     env:
       ARM_CLIENT_ID: ${{ secrets.AZURE_AD_CLIENT_ID }}
-      ARM_CLIENT_SECRET: ${{ secrets.AZURE_AD_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
+      ARM_USE_OIDC: true
       TF_WORKSPACE: prod
       TF_IN_AUTOMATION: true
       TF_INPUT: 0
@@ -30,7 +36,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Azure CLI setup
+        uses: azure/login@v1
+        with:
+          client-id: ${{ env.ARM_CLIENT_ID }}
+          tenant-id: ${{ env.ARM_TENANT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
 
       - name: 'Terraform Format'
         id: fmt

--- a/azure/README.md
+++ b/azure/README.md
@@ -34,11 +34,16 @@ The output includes credentials that you must protect. Be sure that you do not i
 }
 ```
 
-Once the service principal is created, store the following secrets in your CI/CD platform:
+Once the service principal is created, store the following secrets:
 * `AZURE_AD_CLIENT_ID` – This will be the `appId` from above
-* `AZURE_AD_CLIENT_SECRET` – This will be the `password` from above
 * `AZURE_AD_TENANT_ID` – The Azure AD tenant ID to where the service principal was created. This is the `tenant` from above.
 * `AZURE_SUBSCRIPTION_ID` – Subscription ID of where you want to deploy the Terraform. This can be found in the output of `az account subscription list`.
+
+```bash
+# Create federated credentials for the service principal
+az rest --method POST --uri 'https://graph.microsoft.com/beta/applications/<APPLICATION-OBJECT-ID>/federatedIdentityCredentials' --body '{"name":"acm-uic-iac-main","issuer":"https://token.actions.githubusercontent.com","subject":"repo:acm-uic/IaC:ref:refs/heads/main","description":"","audiences":["api://AzureADTokenExchange"]}'
+az rest --method POST --uri 'https://graph.microsoft.com/beta/applications/<APPLICATION-OBJECT-ID>/federatedIdentityCredentials' --body '{"name":"acm-uic-iac-pulls","issuer":"https://token.actions.githubusercontent.com","subject":"repo:acm-uic/IaC:pull_request","description":"","audiences":["api://AzureADTokenExchange"]}'
+```
 
 Once the secrets are in place, ensure the appropriate pipelines have permission to access these secrets.
 They can usually be defined as environment variables for use by the pipelines.


### PR DESCRIPTION
Using federated auth instead of client secrets to avoid having to deal with renewing secrets.
![image](https://github.com/acm-uic/IaC/assets/5100938/553d64b2-b469-4de7-bd19-597594649481)

Made updates to the AAD application to add the federated credentials for pull requests, and main branch.
![image](https://github.com/acm-uic/IaC/assets/5100938/2470aa45-744f-470f-9ff2-7612d8f38fed)