### PR TITLE
🧹 remove unnecessary "name: ''" from helm argocd applications

### DIFF
--- a/kubernetes/argocd/stacks/common/argocd.yml
+++ b/kubernetes/argocd/stacks/common/argocd.yml
@@ -7,7 +7,6 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
-    name: ''
     namespace: argocd
     server: 'https://kubernetes.default.svc'
   sources:

--- a/kubernetes/argocd/stacks/common/ingress-forwarder.yml
+++ b/kubernetes/argocd/stacks/common/ingress-forwarder.yml
@@ -7,7 +7,6 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
-    name: ''
     namespace: ingress-forwarder
     server: 'https://kubernetes.default.svc'
   sources:


### PR DESCRIPTION
remove unnecessary "name: ''" from helm argocd applications

"iac" application goes out of sync with this diff:
![image](https://github.com/acm-uic/IaC/assets/5100938/c4db18ff-a735-4da8-b0bc-89d8b05e66ea)
