### PR TITLE
✨ Moving Sparkhacks 2023 site to Kubernetes

### DIFF
--- a/kubernetes/argocd/stacks/common/projects.yml
+++ b/kubernetes/argocd/stacks/common/projects.yml
@@ -60,4 +60,24 @@ spec:
   # A role which provides read-only access to all applications in the project
   - name: read-only
     description: Read-only privileges to sigsysadmin
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: sparkhacks
+  namespace: argocd
+spec:
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  destinations:
+  - namespace: 'sparkhacks'
+    server: '*'
+  sourceRepos:
+  - 'git@github.com:acm-uic/IaC.git'
+  - 'https://acm.cs.uic.edu/helm'
+  roles:
+  # A role which provides read-only access to all applications in the project
+  - name: read-only
+    description: Read-only privileges to sparkhacks
 

--- a/kubernetes/argocd/stacks/common/sparkhacks.yml
+++ b/kubernetes/argocd/stacks/common/sparkhacks.yml
@@ -12,7 +12,7 @@ spec:
   sources:
     - path: kubernetes/argocd/stacks/sparkhacks
       repoURL: 'git@github.com:acm-uic/IaC.git'
-      targetRevision: feature/sparkhacks-2023-in-k8s
+      targetRevision: HEAD
       directory:
         recurse: true
         include: '*.yml'

--- a/kubernetes/argocd/stacks/common/sparkhacks.yml
+++ b/kubernetes/argocd/stacks/common/sparkhacks.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sparkhacks
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: sparkhacks
+    server: 'https://kubernetes.default.svc'
+  sources:
+    - path: kubernetes/argocd/stacks/sparkhacks
+      repoURL: 'git@github.com:acm-uic/IaC.git'
+      targetRevision: HEAD
+      directory:
+        recurse: true
+        include: '*.yml'
+        exclude: values.yml
+  project: sparkhacks
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/kubernetes/argocd/stacks/common/sparkhacks.yml
+++ b/kubernetes/argocd/stacks/common/sparkhacks.yml
@@ -12,7 +12,7 @@ spec:
   sources:
     - path: kubernetes/argocd/stacks/sparkhacks
       repoURL: 'git@github.com:acm-uic/IaC.git'
-      targetRevision: HEAD
+      targetRevision: feature/sparkhacks-2023-in-k8s
       directory:
         recurse: true
         include: '*.yml'

--- a/kubernetes/argocd/stacks/ingress-forwarder/ingress-forwarder.yml
+++ b/kubernetes/argocd/stacks/ingress-forwarder/ingress-forwarder.yml
@@ -51,41 +51,6 @@ spec:
       targetPort: 443
   externalName: 172.29.0.31
 ---
-apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
-metadata:
-  name: sparkhacksatuic
-  namespace: ingress-forwarder
-spec:
-  entryPoints:
-    - websecure
-  routes:
-    - match: "Host(`sparkhacksatuic.com`) || Host(`www.sparkhacksatuic.com`)"
-      kind: Rule
-      services:
-        - name: docker1
-          namespace: ingress-forwarder
-          passHostHeader: true
-          kind: Service
-          port: 443
-          scheme: https
-  tls:
-    secretName: sparkhacks-cert
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: sparkhacks-cert
-  namespace: ingress-forwarder
-spec:
-  dnsNames:
-    - www.sparkhacksatuic.com
-    - sparkhacksatuic.com
-  secretName: sparkhacks-cert
-  issuerRef:
-    kind: ClusterIssuer
-    name: letsencrypt
----
 kind: Service
 apiVersion: v1
 metadata:

--- a/kubernetes/argocd/stacks/sparkhacks/certs.yml
+++ b/kubernetes/argocd/stacks/sparkhacks/certs.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: sparkhacks-tls
+spec:
+  dnsNames:
+    - sparkhacksatuic.com
+  secretName: sparkhacks-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt

--- a/kubernetes/argocd/stacks/sparkhacks/sparkhacks-2023.yml
+++ b/kubernetes/argocd/stacks/sparkhacks/sparkhacks-2023.yml
@@ -79,15 +79,3 @@ spec:
           weight: 10
   tls:
     secretName: sparkhacks-tls
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: sparkhacks-tls
-spec:
-  dnsNames:
-    - sparkhacks.acmuic.org
-  secretName: sparkhacks-tls
-  issuerRef:
-    kind: ClusterIssuer
-    name: letsencrypt

--- a/kubernetes/argocd/stacks/sparkhacks/sparkhacks-2023.yml
+++ b/kubernetes/argocd/stacks/sparkhacks/sparkhacks-2023.yml
@@ -1,0 +1,93 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sparkhacks-2023
+  namespace: sparkhacks
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sparkhacks-2023
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: sparkhacks-2023
+    spec:
+      containers:
+        - name: sparkhacks-2023
+          image: "ghcr.io/acm-uic/sparkhacks-2023:main"
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            limits:
+              cpu: '500m'
+              memory: 512Mi
+            requests:
+              cpu: '100m'
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: sparkhacks
+  name: sparkhacks-2023
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: sparkhacks-2023
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: sparkhacks
+  namespace: sparkhacks
+  annotations:
+    external-dns.alpha.kubernetes.io/target: app.acmuic.org
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: "Host(`sparkhacksatuic.com`) || Host(`www.sparkhacksatuic.com`)"
+      services:
+        - kind: Service
+          name: sparkhacks
+          namespace: sparkhacks
+          passHostHeader: true
+          port: http
+          responseForwarding:
+            flushInterval: 1ms
+          scheme: http
+          strategy: RoundRobin
+          weight: 10
+  tls:
+    secretName: sparkhacks-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: sparkhacks-tls
+spec:
+  dnsNames:
+    - sparkhacks.acmuic.org
+  secretName: sparkhacks-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt


### PR DESCRIPTION
This PR adds the SparkHacks 2023 site to the Kubernetes cluster.

Note the https://github.com/acm-uic/sparkhacks-2023/pull/235 creates the container being used here.

Additional work:
- Removes the external service referencing the `docker2` server
- Issues the Let's Encrypt certificate for all of `sparkhacksatuic.com`
- Creates a `sparkhacks` project within ArgoCD to organize apps.