### PR TITLE
Serve openid configuration and public key used for service account token signing to enable support for workload identity

### DIFF
--- a/kubernetes/argocd/stacks/common/k8s-oidc.yml
+++ b/kubernetes/argocd/stacks/common/k8s-oidc.yml
@@ -1,0 +1,24 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: workload-identity
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: plausible
+    server: "https://kubernetes.default.svc"
+  sources:
+    - path: kubernetes/argocd/stacks/workload-identity
+      repoURL: "git@github.com:acm-uic/IaC.git"
+      targetRevision: HEAD
+      ref: values
+      directory:
+        recurse: true
+        include: "*.yml"
+  project: infrastructure
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/kubernetes/argocd/stacks/workload-identity/openid-configuration-serve.yml
+++ b/kubernetes/argocd/stacks/workload-identity/openid-configuration-serve.yml
@@ -1,0 +1,152 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workload-identity-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: workload-identity-system
+data:
+  nginx.conf: |
+    server {
+        listen       80;
+        listen  [::]:80;
+        server_name  localhost;
+        default_type appliction/json;
+    
+        location / {
+            root   /usr/share/nginx/html;
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: workload-identity-system
+  name: nginx-deployment
+  labels:
+    app.kubernetes.io/name: k8s-oidc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: k8s-oidc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: k8s-oidc
+    spec:
+      tolerations:
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: serve-volume
+          mountPath: /usr/share/nginx/html
+          readOnly: true
+        - name: nginx-conf
+          mountPath: /etc/nginx/conf.d/default.conf
+          subPath: nginx.conf
+          readOnly: true
+        readinessProbe:
+          httpGet:
+            path: /.well-known/openid-configuration
+            port: 80
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /.well-known/openid-configuration
+            port: 80
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+      initContainers:
+      - name: init-azwi
+        image: bitnami/kubectl
+        command: ["/bin/sh", "-c"]
+        args: 
+        - |
+          mkdir -p /serve/openid/v1 /serve/.well-known
+          kubectl get --raw '/.well-known/openid-configuration' | jq > /serve/.well-known/openid-configuration
+          kubectl get --raw '/openid/v1/jwks' | jq > /serve/openid/v1/jwks
+        volumeMounts:
+        - name: serve-volume
+          mountPath: /serve
+      volumes:
+      - name: serve-volume
+        emptyDir: {}
+      - name: nginx-conf
+        configMap:
+          name: nginx-conf
+          items:
+            - key: nginx.conf
+              path: nginx.conf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8s-oidc
+  namespace: workload-identity-system
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: k8s-oidc
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: k8s-oidc
+  namespace: workload-identity-system
+  annotations:
+    external-dns.alpha.kubernetes.io/target: app.acmuic.org
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`k8s-oidc.acmuic.org`)
+      services:
+        - kind: Service
+          name: k8s-oidc
+          namespace: workload-identity-system
+          passHostHeader: true
+          port: 80
+          responseForwarding:
+            flushInterval: 1ms
+          scheme: http
+          strategy: RoundRobin
+          weight: 10
+  tls:
+    secretName: k8s-oidc-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: k8s-oidc-tls
+  namespace: workload-identity-system
+spec:
+  dnsNames:
+    - k8s-oidc.acmuic.org
+  secretName: k8s-oidc-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt
+---


### PR DESCRIPTION
This manifest adds a `nginx` container that serves the following

jwks: https://k8s-oidc.acmuic.org/openid/v1/jwks
openid-configuration: https://k8s-oidc.acmuic.org/.well-known/openid-configuration


The files to serve are obtained by an init container which gets the jwks, openid-configuration from the api server via `kubectl`

Changed made in machine config:
- Add args to api server with the new issuer
- Generate new RSA key to be use for service account token signing

Keys generated and applied with this script
```bash
#!/bin/bash

set -v

TALOSCONFIG=./k8s-talosconfig
KUBECONFIG=./k8s-kubeconfig
ISSUER=https://k8s-oidc.acmuic.org
JWKS_URI=https://k8s-oidc.acmuic.org/openid/v1/jwks

RSA_KEY=$(openssl genrsa 4096 2> /dev/null | openssl pkey -traditional)
RSA_KEY_ENCODED=$(echo "${RSA_KEY}" | base64 -w 0)

CONTROL_PLANE_NODES=( "k8s-01" "k8s-02" "k8s-03" )
ENDPOINTS="k8s-01.acmuic.org,k8s-02.acmuic.org,k8s-03.acmuic.org"

API_SERVER_PATCH=$(cat <<EOF
[
  {
    "op": "add",
    "path": "/cluster/apiServer",
    "value": {
      "disablePodSecurityPolicy": true,
      "extraArgs": {
        "service-account-issuer": "${ISSUER}",
        "service-account-jwks-uri": "${JWKS_URI}"
      }
    }
  },
  {
    "op": "replace",
    "path": "/cluster/serviceAccount",
    "value": {
      "key": "${RSA_KEY_ENCODED}"
    }
  }
]
EOF
)

for NODE in "${CONTROL_PLANE_NODES[@]}"; do
    echo ${NODE}
    talosctl \
        --talosconfig ${TALOSCONFIG} \
	--endpoints "${ENDPOINTS}" \
        --nodes "${NODE}" \
        patch mc \
        --patch "${API_SERVER_PATCH}"
done

```