### PR TITLE
💪🏽 allow repo https://azure.github.io/azure-workload-identity/charts in infrastructure project

### DIFF
--- a/kubernetes/argocd/stacks/common/projects.yml
+++ b/kubernetes/argocd/stacks/common/projects.yml
@@ -36,6 +36,7 @@ spec:
   - 'https://acm.cs.uic.edu/helm'
   - 'https://helm.releases.hashicorp.com'
   - 'https://kubernetes-sigs.github.io/metrics-server/'
+  - 'https://azure.github.io/azure-workload-identity/charts'
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only


### PR DESCRIPTION
Fix error: `application repo https://azure.github.io/azure-workload-identity/charts is not permitted in project 'infrastructure'`

![image](https://github.com/user-attachments/assets/1a8d2644-8442-424b-ae38-690cd4ee7f2d)
