### PR TITLE
Bug/Fix pfSense ACME renewals

### DIFF
--- a/azure/terraform/stacks/acm-general/pfsense.tf
+++ b/azure/terraform/stacks/acm-general/pfsense.tf
@@ -17,6 +17,9 @@ resource "azuread_service_principal" "pfsense" {
   owners      = var.additional_owner_ids
 }
 
+# This password exires every 2 years
+# You'll need to update this in pfSense manually:
+# Services > Acme Certificates > (edit the cert) > Domain SAN list > (expand(+) DNS-Azure (Microsoft) > Client Secret
 resource "azuread_service_principal_password" "pfsense" {
   service_principal_id = azuread_service_principal.pfsense.id
   display_name         = "pfsensePassword"
@@ -35,6 +38,6 @@ output "pfsense_service_principal_id" {
 }
 
 output "pfsense_service_principal_password" {
-  value = azuread_service_principal_password.pfsense.value
+  value     = azuread_service_principal_password.pfsense.value
   sensitive = true
 }

--- a/azure/terraform/stacks/acm-general/pfsense.tf
+++ b/azure/terraform/stacks/acm-general/pfsense.tf
@@ -1,0 +1,40 @@
+# https://github.com/acmesh-official/acme.sh/wiki/How-to-use-Azure-DNS
+#
+# This is a service principal that is used by PFSense to manage DNS records
+# for the ACME challenges.
+
+
+# az ad sp create-for-rbac --name pfsenseServiceApp --role "DNS Zone Contributor" --scopes /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/acme-general/providers/Microsoft.Network/dnszones/acme.chase.net
+
+resource "azuread_application" "pfsense" {
+  display_name = "pfsenseServiceApp"
+  owners       = var.additional_owner_ids
+}
+
+resource "azuread_service_principal" "pfsense" {
+  client_id   = azuread_application.pfsense.client_id
+  description = "Service Principal for on-prem pfSense"
+  owners      = var.additional_owner_ids
+}
+
+resource "azuread_service_principal_password" "pfsense" {
+  service_principal_id = azuread_service_principal.pfsense.id
+  display_name         = "pfsensePassword"
+}
+
+# Lookup existing role asisgnments
+# `az role assignment list --all | grep "<principal_id>" -B10 -A10`
+resource "azurerm_role_assignment" "pfsense_dns_contributor" {
+  scope                = data.azurerm_dns_zone.acmuic_org.id
+  role_definition_name = "DNS Zone Contributor"
+  principal_id         = azuread_service_principal.pfsense.object_id
+}
+
+output "pfsense_service_principal_id" {
+  value = azuread_service_principal.pfsense.id
+}
+
+output "pfsense_service_principal_password" {
+  value = azuread_service_principal_password.pfsense.value
+  sensitive = true
+}


### PR DESCRIPTION
This adds Terraform resource definitions to manage the `pfSenseServiceApp`.

This application is in charge of providing pfSense credentials in Azure to manage DNS records in the `acmuic.org` DNS zone.