### PR TITLE
🤵Maid Café - Kubernetes Cluster 7

### DIFF
--- a/proxmox/terraform/stacks/maid-cafe-k8s/k8s-01.tf
+++ b/proxmox/terraform/stacks/maid-cafe-k8s/k8s-01.tf
@@ -35,6 +35,7 @@ resource "proxmox_vm_qemu" "k8s_01" {
     model    = "virtio"
     bridge   = "speed2"
     firewall = true
+    tag      = 9
     macaddr  = "BC:24:11:84:15:8B"
   }
 
@@ -57,7 +58,7 @@ resource "proxmox_vm_qemu" "k8s_01" {
   disk {
     slot = "ide2"
     type = "cdrom"
-    iso  = "cephfs:iso/taloslinux-cached-amd64-20250522.iso"
+    iso  = "cephfs:iso/taloslinux-cached-amd64-20250528.iso"
   }
 
   lifecycle {

--- a/proxmox/terraform/stacks/maid-cafe-k8s/k8s-02.tf
+++ b/proxmox/terraform/stacks/maid-cafe-k8s/k8s-02.tf
@@ -35,6 +35,7 @@ resource "proxmox_vm_qemu" "k8s_02" {
     model    = "virtio"
     bridge   = "speed2"
     firewall = true
+    tag      = 9
     macaddr  = "BC:24:11:52:BC:A2"
   }
 
@@ -57,7 +58,7 @@ resource "proxmox_vm_qemu" "k8s_02" {
   disk {
     slot = "ide2"
     type = "cdrom"
-    iso  = "cephfs:iso/taloslinux-cached-amd64-20250522.iso"
+    iso  = "cephfs:iso/taloslinux-cached-amd64-20250528.iso"
   }
 
   lifecycle {

--- a/proxmox/terraform/stacks/maid-cafe-k8s/k8s-03.tf
+++ b/proxmox/terraform/stacks/maid-cafe-k8s/k8s-03.tf
@@ -35,6 +35,7 @@ resource "proxmox_vm_qemu" "k8s_03" {
     model    = "virtio"
     bridge   = "speed2"
     firewall = true
+    tag      = 9
     macaddr  = "BC:24:11:E4:10:66"
   }
 
@@ -57,7 +58,7 @@ resource "proxmox_vm_qemu" "k8s_03" {
   disk {
     slot = "ide2"
     type = "cdrom"
-    iso  = "cephfs:iso/taloslinux-cached-amd64-20250522.iso"
+    iso  = "cephfs:iso/taloslinux-cached-amd64-20250528.iso"
   }
 
   lifecycle {

--- a/proxmox/terraform/stacks/maid-cafe-k8s/k8s-04.tf
+++ b/proxmox/terraform/stacks/maid-cafe-k8s/k8s-04.tf
@@ -58,7 +58,7 @@ resource "proxmox_vm_qemu" "k8s_04" {
   disk {
     slot = "ide2"
     type = "cdrom"
-    iso  = "cephfs:iso/taloslinux-cached-amd64-20250522.iso"
+    iso  = "cephfs:iso/taloslinux-cached-amd64-20250528.iso"
   }
 
   lifecycle {

--- a/proxmox/terraform/stacks/maid-cafe-k8s/k8s-05.tf
+++ b/proxmox/terraform/stacks/maid-cafe-k8s/k8s-05.tf
@@ -58,7 +58,7 @@ resource "proxmox_vm_qemu" "k8s_05" {
   disk {
     slot = "ide2"
     type = "cdrom"
-    iso  = "cephfs:iso/taloslinux-cached-amd64-20250522.iso"
+    iso  = "cephfs:iso/taloslinux-cached-amd64-20250528.iso"
   }
 
   lifecycle {

--- a/proxmox/terraform/stacks/maid-cafe-k8s/k8s-06.tf
+++ b/proxmox/terraform/stacks/maid-cafe-k8s/k8s-06.tf
@@ -58,7 +58,7 @@ resource "proxmox_vm_qemu" "k8s_06" {
   disk {
     slot = "ide2"
     type = "cdrom"
-    iso  = "cephfs:iso/taloslinux-cached-amd64-20250522.iso"
+    iso  = "cephfs:iso/taloslinux-cached-amd64-20250528.iso"
   }
 
   lifecycle {

--- a/proxmox/terraform/stacks/maid-cafe-k8s/k8s-07.tf
+++ b/proxmox/terraform/stacks/maid-cafe-k8s/k8s-07.tf
@@ -58,7 +58,7 @@ resource "proxmox_vm_qemu" "k8s_07" {
   disk {
     slot = "ide2"
     type = "cdrom"
-    iso  = "cephfs:iso/taloslinux-cached-amd64-20250522.iso"
+    iso  = "cephfs:iso/taloslinux-cached-amd64-20250528.iso"
   }
 
   lifecycle {

--- a/proxmox/terraform/stacks/maid-cafe-k8s/k8s-08.tf
+++ b/proxmox/terraform/stacks/maid-cafe-k8s/k8s-08.tf
@@ -58,7 +58,7 @@ resource "proxmox_vm_qemu" "k8s_08" {
   disk {
     slot = "ide2"
     type = "cdrom"
-    iso  = "cephfs:iso/taloslinux-cached-amd64-20250522.iso"
+    iso  = "cephfs:iso/taloslinux-cached-amd64-20250528.iso"
   }
 
   lifecycle {


### PR DESCRIPTION
Bumping image used for K8s VMs. Tagging all VMs with VLAN 9.